### PR TITLE
Handle new identifier structure

### DIFF
--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -193,7 +193,7 @@ func (s service) Initialise() error {
 func createAnnotationRelationship(relation string) (statement string) {
 	stmt := `
                 MERGE (content:Thing{uuid:{contentID}})
-                MERGE (upp:UPPIdentifier{value:{conceptID}})
+                MERGE (upp:Identifier:UPPIdentifier{value:{conceptID}})
                 MERGE (upp)-[:IDENTIFIES]->(concept:Thing) ON CREATE SET concept.uuid = {conceptID}
                 MERGE (content)-[pred:%s{platformVersion:{platformVersion}}]->(concept)
                 SET pred={annProps}

--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -106,10 +106,10 @@ func (s service) Delete(contentUUID string) (bool, error) {
 		deleteStatement = `MATCH (c:Thing{uuid: {contentUUID}})-[rel{platformVersion:{platformVersion}}]->(cc:Thing) DELETE rel`
 	}
 
-	fmt.Printf("this is the statements i will execute:"+deleteStatement)
+	fmt.Printf("this is the statements i will execute:" + deleteStatement)
 
 	query := &neoism.CypherQuery{
-		Statement:   deleteStatement,
+		Statement:    deleteStatement,
 		Parameters:   neoism.Props{"contentUUID": contentUUID, "platformVersion": s.platformVersion},
 		IncludeStats: true,
 	}

--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -59,7 +59,6 @@ func (s service) Read(contentUUID string) (thing interface{}, found bool, err er
 	//TODO shouldn't return Provenances if none of the scores, agentRole or atTime are set
 	statementTemplate := `
 					MATCH (c:Thing{uuid:{contentUUID}})-[rel{platformVersion:{platformVersion}}]->(cc:Thing)
-					MATCH (cc:Thing)
 					WITH c, cc, rel, {id:cc.uuid,prefLabel:cc.prefLabel,types:labels(cc),predicate:type(rel)} as thing,
 					collect(
 						{scores:[

--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -106,8 +106,6 @@ func (s service) Delete(contentUUID string) (bool, error) {
 		deleteStatement = `MATCH (c:Thing{uuid: {contentUUID}})-[rel{platformVersion:{platformVersion}}]->(cc:Thing) DELETE rel`
 	}
 
-	fmt.Printf("this is the statements i will execute:" + deleteStatement)
-
 	query := &neoism.CypherQuery{
 		Statement:    deleteStatement,
 		Parameters:   neoism.Props{"contentUUID": contentUUID, "platformVersion": s.platformVersion},


### PR DESCRIPTION
This PR adjust the RW for the new identifier structures. 

The changes imply:
- at write time: instead of looking at concept nodes uuid, the UPPIdentifier's value is checked. If the concept node is not yet loaded: create the concept node as Thing{uuid}, a UPPIdentifier{value=uuid} node, and the IDENTIFIES relationship between them
- the delete query is also updated to delete all the annotation relationships for v1 concepts, and only MENTIONS relationships for v2 concepts