### PR TITLE
Resurect handling of UPPIdentifiers and use new NeoUtils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,28 @@
 FROM alpine:3.3
-
-ADD *.go /annotations-rw-neo4j/
-ADD annotations/*.go /annotations-rw-neo4j/annotations/
-
+ADD *.go .git /public-annotations-api/
+ADD annotations/*.go /public-annotations-api/annotations/
 RUN apk add --update bash \
-  && apk --update add git bzr \
-  && apk --update add go \
+  && apk --update add git go \
+  && cd public-annotations-api \
+  && git fetch origin 'refs/tags/*:refs/tags/*' \
+  && BUILDINFO_PACKAGE="github.com/Financial-Times/service-status-go/buildinfo." \
+  && VERSION="version=$(git describe --tag --always 2> /dev/null)" \
+  && DATETIME="dateTime=$(date -u +%Y%m%d%H%M%S)" \
+  && REPOSITORY="repository=$(git config --get remote.origin.url)" \
+  && REVISION="revision=$(git rev-parse HEAD)" \
+  && BUILDER="builder=$(go version)" \
+  && LDFLAGS="-X '"${BUILDINFO_PACKAGE}$VERSION"' -X '"${BUILDINFO_PACKAGE}$DATETIME"' -X '"${BUILDINFO_PACKAGE}$REPOSITORY"' -X '"${BUILDINFO_PACKAGE}$REVISION"' -X '"${BUILDINFO_PACKAGE}$BUILDER"'" \
+  && cd .. \
   && export GOPATH=/gopath \
-  && REPO_PATH="github.com/Financial-Times/annotations-rw-neo4j" \
+  && REPO_PATH="github.com/Financial-Times/public-annotations-api" \
   && mkdir -p $GOPATH/src/${REPO_PATH} \
-  && cp -r annotations-rw-neo4j/* $GOPATH/src/${REPO_PATH} \
+  && cp -r public-annotations-api/* $GOPATH/src/${REPO_PATH} \
   && cd $GOPATH/src/${REPO_PATH} \
-  && go get -t ./... \
-  && go build \
-  && mv annotations-rw-neo4j /app \
-  && apk del go git bzr \
+  && go get ./... \
+  && cd $GOPATH/src/${REPO_PATH} \
+  && echo ${LDFLAGS} \
+  && go build -ldflags="${LDFLAGS}" \
+  && mv public-annotations-api /app \
+  && apk del go git \
   && rm -rf $GOPATH /var/cache/apk/*
-
-CMD exec /app --neo-url=$NEO_URL --port=$APP_PORT --batchSize=$BATCH_SIZE --graphiteTCPAddress=$GRAPHITE_ADDRESS --graphitePrefix=$GRAPHITE_PREFIX --logMetrics=$LOG_METRICS --platformVersion=$PLATFORM_VERSION
+CMD exec /app --neo-url=$NEO_URL --port=$APP_PORT --graphiteTCPAddress=$GRAPHITE_ADDRESS --graphitePrefix=$GRAPHITE_PREFIX --logMetrics=$LOG_METRICS --cache-duration=$CACHE_DURATION

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,5 @@ RUN apk add --update bash \
   && mv public-annotations-api /app \
   && apk del go git \
   && rm -rf $GOPATH /var/cache/apk/*
-CMD exec /app --neo-url=$NEO_URL --port=$APP_PORT --graphiteTCPAddress=$GRAPHITE_ADDRESS --graphitePrefix=$GRAPHITE_PREFIX --logMetrics=$LOG_METRICS --cache-duration=$CACHE_DURATION
+CMD exec /app --neo-url=$NEO_URL --port=$APP_PORT --batchSize=$BATCH_SIZE --graphiteTCPAddress=$GRAPHITE_ADDRESS --graphitePrefix=$GRAPHITE_PREFIX --logMetrics=false --env=local
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM alpine:3.3
-ADD *.go .git /public-annotations-api/
-ADD annotations/*.go /public-annotations-api/annotations/
+ADD *.go .git /annotations-rw-neo4j/
+ADD annotations/*.go /annotations-rw-neo4j/annotations/
 RUN apk add --update bash \
   && apk --update add git go \
-  && cd public-annotations-api \
+  && cd annotations-rw-neo4j \
   && git fetch origin 'refs/tags/*:refs/tags/*' \
   && BUILDINFO_PACKAGE="github.com/Financial-Times/service-status-go/buildinfo." \
   && VERSION="version=$(git describe --tag --always 2> /dev/null)" \
@@ -14,15 +14,15 @@ RUN apk add --update bash \
   && LDFLAGS="-X '"${BUILDINFO_PACKAGE}$VERSION"' -X '"${BUILDINFO_PACKAGE}$DATETIME"' -X '"${BUILDINFO_PACKAGE}$REPOSITORY"' -X '"${BUILDINFO_PACKAGE}$REVISION"' -X '"${BUILDINFO_PACKAGE}$BUILDER"'" \
   && cd .. \
   && export GOPATH=/gopath \
-  && REPO_PATH="github.com/Financial-Times/public-annotations-api" \
+  && REPO_PATH="github.com/Financial-Times/annotations-rw-neo4j" \
   && mkdir -p $GOPATH/src/${REPO_PATH} \
-  && cp -r public-annotations-api/* $GOPATH/src/${REPO_PATH} \
+  && cp -r annotations-rw-neo4j/* $GOPATH/src/${REPO_PATH} \
   && cd $GOPATH/src/${REPO_PATH} \
   && go get ./... \
   && cd $GOPATH/src/${REPO_PATH} \
   && echo ${LDFLAGS} \
   && go build -ldflags="${LDFLAGS}" \
-  && mv public-annotations-api /app \
+  && mv annotations-rw-neo4j /app \
   && apk del go git \
   && rm -rf $GOPATH /var/cache/apk/*
 CMD exec /app --neo-url=$NEO_URL --port=$APP_PORT --batchSize=$BATCH_SIZE --graphiteTCPAddress=$GRAPHITE_ADDRESS --graphitePrefix=$GRAPHITE_PREFIX --logMetrics=false --env=local --platformVersion=$PLATFORM_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,5 @@ RUN apk add --update bash \
   && mv public-annotations-api /app \
   && apk del go git \
   && rm -rf $GOPATH /var/cache/apk/*
-CMD exec /app --neo-url=$NEO_URL --port=$APP_PORT --batchSize=$BATCH_SIZE --graphiteTCPAddress=$GRAPHITE_ADDRESS --graphitePrefix=$GRAPHITE_PREFIX --logMetrics=false --env=local
+CMD exec /app --neo-url=$NEO_URL --port=$APP_PORT --batchSize=$BATCH_SIZE --graphiteTCPAddress=$GRAPHITE_ADDRESS --graphitePrefix=$GRAPHITE_PREFIX --logMetrics=false --env=local --platformVersion=$PLATFORM_VERSION
 

--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -33,17 +33,16 @@ type Service interface {
 
 //holds the Neo4j-specific information
 type service struct {
-	cypherRunner    neoutils.CypherRunner
-	indexManager    neoutils.IndexManager
+	cypherRunner neoutils.NeoConnection
 	platformVersion string
 }
 
-//NewAnnotationsService instantiate driver
-func NewAnnotationsService(cypherRunner neoutils.CypherRunner, indexManager neoutils.IndexManager, platformVersion string) service {
+//NewCypherAnnotationsService instantiate driver
+func NewCypherAnnotationsService(cypherRunner neoutils.NeoConnection,  platformVersion string) service {
 	if platformVersion == "" {
 		log.Fatalf("PlatformVersion was not specified!")
 	}
-	return service{cypherRunner, indexManager, platformVersion}
+	return service{cypherRunner, platformVersion}
 }
 
 // DecodeJSON decodes to a list of annotations, for ease of use this is a struct itself

--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -192,7 +192,7 @@ func createAnnotationRelationship(relation string) (statement string) {
                 MERGE (content:Thing{uuid:{contentID}})
                 MERGE (upp:Identifier:UPPIdentifier{value:{conceptID}})
                 MERGE (upp)-[:IDENTIFIES]->(concept:Thing) ON CREATE SET concept.uuid = {conceptID}
-                MERGE (content)-[pred:%s {platformVersion:{platformVersion}, lifecycle: {lifecycle}}]->(concept)
+                MERGE (content)-[pred:%s {platformVersion:{platformVersion}}]->(concept)
                 SET pred={annProps}
           `
 	statement = fmt.Sprintf(stmt, relation)
@@ -223,6 +223,7 @@ func createAnnotationQuery(contentUUID string, ann annotation, platformVersion s
 	var prov provenance
 	params := map[string]interface{}{}
 	params["platformVersion"] = platformVersion
+	params["lifecycle"] = "annotations-" + platformVersion
 
 	if len(ann.Provenances) >= 1 {
 		prov = ann.Provenances[0]
@@ -252,7 +253,6 @@ func createAnnotationQuery(contentUUID string, ann annotation, platformVersion s
 		"contentID":       contentUUID,
 		"conceptID":       thingID,
 		"platformVersion": platformVersion,
-		"lifecycle":       "annotations-" + platformVersion,
 		"annProps":        params,
 	}
 	return &query, nil
@@ -323,11 +323,11 @@ func dropAllAnnotationsQuery(contentUUID string, platformVersion string) *neoism
 	// -> so far brands are the only v2 concepts which have isClassifiedBy relationship; as soon as this changes: implementation needs to be updated
 	if platformVersion == "v2" {
 		matchStmtTemplate = `OPTIONAL MATCH (:Thing{uuid:{contentID}})-[r:MENTIONS{platformVersion:{platformVersion}}]->(t:Thing)
-                        DELETE r`
+                         DELETE r`
 	} else {
 		matchStmtTemplate = `OPTIONAL MATCH (:Thing{uuid:{contentID}})-[r]->(t:Thing)
-			WHERE r.platformVersion={platformVersion}
-                        DELETE r`
+												    WHERE r.platformVersion={platformVersion}
+                         DELETE r`
 	}
 
 	query := neoism.CypherQuery{}

--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -89,7 +89,7 @@ func (s service) Read(contentUUID string) (thing interface{}, found bool, err er
 		mapToResponseFormat(&results[idx])
 	}
 
-	return results, true, nil
+	return annotations(results), true, nil
 }
 
 //Delete removes all the annotations for this content. Ignore the nodes on either end -

--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -33,7 +33,7 @@ type Service interface {
 
 //holds the Neo4j-specific information
 type service struct {
-	cypherRunner neoutils.NeoConnection
+	conn  neoutils.NeoConnection
 	platformVersion string
 }
 
@@ -74,7 +74,7 @@ func (s service) Read(contentUUID string) (thing interface{}, found bool, err er
 		Parameters: neoism.Props{"contentUUID": contentUUID, "platformVersion": s.platformVersion},
 		Result:     &results,
 	}
-	err = s.cypherRunner.CypherBatch([]*neoism.CypherQuery{query})
+	err = s.conn.CypherBatch([]*neoism.CypherQuery{query})
 	if err != nil {
 		log.Errorf("Error looking up uuid %s with query %s from neoism: %+v", contentUUID, query.Statement, err)
 		return annotations{}, false, fmt.Errorf("Error accessing Annotations datastore for uuid: %s", contentUUID)
@@ -110,7 +110,7 @@ func (s service) Delete(contentUUID string) (bool, error) {
 		IncludeStats: true,
 	}
 
-	err := s.cypherRunner.CypherBatch([]*neoism.CypherQuery{query})
+	err := s.conn.CypherBatch([]*neoism.CypherQuery{query})
 
 	stats, err := query.Stats()
 	if err != nil {
@@ -151,12 +151,12 @@ func (s service) Write(contentUUID string, thing interface{}) (err error) {
 	log.Infof("Updated Annotations for content uuid: %s", contentUUID)
 	log.Debugf("For update, ran statements: %+v", statements)
 
-	return s.cypherRunner.CypherBatch(queries)
+	return s.conn.CypherBatch(queries)
 }
 
 // Check tests neo4j by running a simple cypher query
 func (s service) Check() error {
-	return neoutils.Check(s.cypherRunner)
+	return neoutils.Check(s.conn)
 }
 
 func (s service) Count() (int, error) {
@@ -173,7 +173,7 @@ func (s service) Count() (int, error) {
 		Result:     &results,
 	}
 
-	err := s.cypherRunner.CypherBatch([]*neoism.CypherQuery{query})
+	err := s.conn.CypherBatch([]*neoism.CypherQuery{query})
 
 	if err != nil {
 		return 0, err

--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -166,10 +166,10 @@ func (s service) Count() (int, error) {
 	}{}
 
 	query := &neoism.CypherQuery{
-		Statement: `MATCH ()-[r{platformVersion:{platformVersion}}]->()
-								WHERE r.lifecycle = {lifecycle}
-								OR r.lifecycle IS NULL
-								RETURN count(r) as c`,
+		Statement: `	MATCH ()-[r{platformVersion:{platformVersion}}]->()
+			 	WHERE r.lifecycle = {lifecycle}
+				OR r.lifecycle IS NULL
+				RETURN count(r) as c`,
 		Parameters: neoism.Props{"platformVersion": s.platformVersion, "lifecycle": "annotations-" + s.platformVersion},
 		Result:     &results,
 	}
@@ -322,12 +322,12 @@ func dropAllAnnotationsQuery(contentUUID string, platformVersion string) *neoism
 	// -> necessary for brands - which got written by content-api with isClassifiedBy relationship, and should not be deleted by annotations-rw
 	// -> so far brands are the only v2 concepts which have isClassifiedBy relationship; as soon as this changes: implementation needs to be updated
 	if platformVersion == "v2" {
-		matchStmtTemplate = `OPTIONAL MATCH (:Thing{uuid:{contentID}})-[r:MENTIONS{platformVersion:{platformVersion}}]->(t:Thing)
-                         DELETE r`
+		matchStmtTemplate = `	OPTIONAL MATCH (:Thing{uuid:{contentID}})-[r:MENTIONS{platformVersion:{platformVersion}}]->(t:Thing)
+                         		DELETE r`
 	} else {
-		matchStmtTemplate = `OPTIONAL MATCH (:Thing{uuid:{contentID}})-[r]->(t:Thing)
-												    WHERE r.platformVersion={platformVersion}
-                         DELETE r`
+		matchStmtTemplate = `	OPTIONAL MATCH (:Thing{uuid:{contentID}})-[r]->(t:Thing)
+					WHERE r.platformVersion={platformVersion}
+                         		DELETE r`
 	}
 
 	query := neoism.CypherQuery{}

--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -316,8 +316,10 @@ func extractScores(scores []score) (float64, float64, error) {
 }
 
 func dropAllAnnotationsQuery(contentUUID string, platformVersion string) *neoism.CypherQuery {
-	matchStmtTemplate := `OPTIONAL MATCH (:Thing{uuid:{contentID}})-[r {platformVersion:{platformVersion}, lifecycle: {lifecycle}}]->(t:Thing)
-											DELETE r`
+	matchStmtTemplate := `OPTIONAL MATCH (:Thing{uuid:{contentID}})-[r {platformVersion:{platformVersion}}]->(t:Thing)
+												WHERE rel.lifecycle = {lifecycle}
+												OR rel.lifecycle IS NULL
+												DELETE r`
 
 	query := neoism.CypherQuery{}
 	query.Statement = matchStmtTemplate

--- a/annotations/cypher_test.go
+++ b/annotations/cypher_test.go
@@ -619,7 +619,7 @@ func getAnnotationsService(t *testing.T, platformVersion string) service {
 func readAnnotationsForContentUUIDAndCheckKeyFieldsMatch(t *testing.T, contentUUID string, expectedAnnotations []annotation) {
 	assert := assert.New(t)
 	storedThings, found, err := annotationsDriver.Read(contentUUID)
-	storedAnnotations := storedThings.([]annotation)
+	storedAnnotations := storedThings.(annotations)
 
 	assert.NoError(err, "Error finding annotations for contentUUID %s", contentUUID)
 	assert.True(found, "Didn't find annotations for contentUUID %s", contentUUID)

--- a/annotations/cypher_test.go
+++ b/annotations/cypher_test.go
@@ -95,7 +95,7 @@ func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithoutLifecy
 		},
 	}
 
-	err := annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{testSetupQuery})
+	err := annotationsDriver.conn.CypherBatch([]*neoism.CypherQuery{testSetupQuery})
 	annotationsToWrite := exampleConcepts(conceptUUID)
 
 	assert.NoError(annotationsDriver.Write(contentUUID, annotationsToWrite), "Failed to write annotation")
@@ -118,7 +118,7 @@ func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithoutLifecy
 		Result: &result,
 	}
 
-	readErr := annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{getContentQuery})
+	readErr := annotationsDriver.conn.CypherBatch([]*neoism.CypherQuery{getContentQuery})
 	assert.NoError(readErr)
 	assert.NotEmpty(result)
 }
@@ -140,7 +140,7 @@ func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithContentLi
 		},
 	}
 
-	err := annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{contentQuery})
+	err := annotationsDriver.conn.CypherBatch([]*neoism.CypherQuery{contentQuery})
 	assert.NoError(err, "Error c for content uuid %s", contentUUID)
 
 	annotationsToWrite := exampleConcepts(conceptUUID)
@@ -165,7 +165,7 @@ func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithContentLi
 		Result: &result,
 	}
 
-	readErr := annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{getContentQuery})
+	readErr := annotationsDriver.conn.CypherBatch([]*neoism.CypherQuery{getContentQuery})
 	assert.NoError(readErr)
 	assert.NotEmpty(result)
 }
@@ -183,7 +183,7 @@ func TestWriteDoesRemoveExistingIsClassifiedForV1TermsAndTheirRelationships(t *t
 		},
 	}
 
-	annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{createContentQuery})
+	annotationsDriver.conn.CypherBatch([]*neoism.CypherQuery{createContentQuery})
 
 	contentQuery := &neoism.CypherQuery{
 		Statement: `MERGE (n:Thing {uuid:{contentUuid}})
@@ -199,7 +199,7 @@ func TestWriteDoesRemoveExistingIsClassifiedForV1TermsAndTheirRelationships(t *t
 		},
 	}
 
-	err := annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{contentQuery})
+	err := annotationsDriver.conn.CypherBatch([]*neoism.CypherQuery{contentQuery})
 
 	assert.NoError(v1AnnotationsDriver.Write(contentUUID, exampleConcepts(conceptUUID)), "Failed to write annotation")
 	found, err := v1AnnotationsDriver.Delete(contentUUID)
@@ -220,7 +220,7 @@ func TestWriteDoesRemoveExistingIsClassifiedForV1TermsAndTheirRelationships(t *t
 		Result: &result,
 	}
 
-	readErr := annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{getContentQuery})
+	readErr := annotationsDriver.conn.CypherBatch([]*neoism.CypherQuery{getContentQuery})
 	assert.NoError(readErr)
 	assert.Empty(result)
 
@@ -234,7 +234,7 @@ func TestWriteDoesRemoveExistingIsClassifiedForV1TermsAndTheirRelationships(t *t
 		Result: &result,
 	}
 
-	readErr = annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{getContentQuery})
+	readErr = annotationsDriver.conn.CypherBatch([]*neoism.CypherQuery{getContentQuery})
 	assert.NoError(readErr)
 	assert.NotEmpty(result)
 
@@ -250,7 +250,7 @@ func TestWriteDoesRemoveExistingIsClassifiedForV1TermsAndTheirRelationships(t *t
 		},
 	}
 
-	annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{removeRelationshipQuery})
+	annotationsDriver.conn.CypherBatch([]*neoism.CypherQuery{removeRelationshipQuery})
 
 	err = deleteNode(annotationsDriver, brandUUID)
 	assert.NoError(err, "Error trying to delete concept node with uuid %s, err=%v", brandUUID, err)
@@ -386,7 +386,7 @@ func checkNodeIsStillPresent(uuid string, t *testing.T) {
 		Result: &results,
 	}
 
-	err := annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{query})
+	err := annotationsDriver.conn.CypherBatch([]*neoism.CypherQuery{query})
 	assert.NoError(err, "UnexpectedError")
 	assert.True(len(results) == 1, "Didn't find a node")
 	assert.Equal(uuid, results[0].UUID, "Did not find correct node")
@@ -408,7 +408,7 @@ func checkConceptNodeIsStillPresent(uuid string, t *testing.T) {
 		Result: &results,
 	}
 
-	err := annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{query})
+	err := annotationsDriver.conn.CypherBatch([]*neoism.CypherQuery{query})
 	assert.NoError(err, "UnexpectedError")
 	assert.True(len(results) == 1, "Didn't find a node")
 	assert.Equal(uuid, results[0].UUID, "Did not find correct node")
@@ -465,7 +465,7 @@ func checkRelationship(assert *assert.Assertions, contentID string, platformVers
 		Result:     &results,
 	}
 
-	err := annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{qs})
+	err := annotationsDriver.conn.CypherBatch([]*neoism.CypherQuery{qs})
 	assert.NoError(err)
 	assert.Equal(1, len(results), "More results found than expected!")
 	assert.Equal(1, results[0].Count, "No Relationship with Lifecycle found!")
@@ -506,7 +506,7 @@ func cleanDB(t *testing.T, assert *assert.Assertions) {
 		},
 	}
 
-	err := annotationsDriver.cypherRunner.CypherBatch(qs)
+	err := annotationsDriver.conn.CypherBatch(qs)
 	assert.NoError(err)
 }
 
@@ -523,5 +523,5 @@ func deleteNode(annotationsDriver service, uuid string) error {
 		},
 	}
 
-	return annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{query})
+	return annotationsDriver.conn.CypherBatch([]*neoism.CypherQuery{query})
 }

--- a/annotations/cypher_test.go
+++ b/annotations/cypher_test.go
@@ -142,6 +142,7 @@ func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithoutLifeCy
 	assert := assert.New(t)
 	annotationsDriver = getAnnotationsService(t, v2PlatformVersion)
 	defer cleanDB(t, assert)
+
 	contentQuery := &neoism.CypherQuery{
 		Statement: `MERGE (n:Thing {uuid:{contentUuid}}) SET n :Thing
 		MERGE (b:Brand{uuid:{brandUuid}}) SET b :Concept:Thing
@@ -258,21 +259,6 @@ func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithContentLi
 	readErr := annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{getContentQuery})
 	assert.NoError(readErr)
 	assert.NotEmpty(result)
-
-	removeRelationshipQuery := &neoism.CypherQuery{
-		Statement: `
-			MATCH (b:Thing {uuid:{brandUuid}})<-[rel:IS_CLASSIFIED_BY]-(t:Thing)
-			DELETE rel
-		`,
-		Parameters: map[string]interface{}{
-			"brandUuid": brandUUID,
-		},
-	}
-
-	annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{removeRelationshipQuery})
-
-	err = deleteNode(annotationsDriver, brandUUID)
-	assert.NoError(err, "Error trying to delete concept node with uuid %s, err=%v", brandUUID, err)
 }
 
 func TestWriteDoesRemoveExistingIsClassifedForV1TermsAndTheirRelationships(t *testing.T) {

--- a/annotations/cypher_test.go
+++ b/annotations/cypher_test.go
@@ -201,7 +201,7 @@ func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithoutLifeCy
 func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithContentLifeCycle(t *testing.T) {
 	assert := assert.New(t)
 	annotationsDriver = getAnnotationsService(t, v2PlatformVersion)
-	//defer cleanDB( t, assert)
+	defer cleanDB(t, assert)
 	contentQuery := &neoism.CypherQuery{
 		Statement: `MERGE (n:Thing {uuid:{contentUuid}}) SET n :Thing
 		MERGE (b:Brand{uuid:{brandUuid}}) SET b :Concept:Thing

--- a/annotations/cypher_test.go
+++ b/annotations/cypher_test.go
@@ -141,7 +141,7 @@ func TestWriteAllValuesPresent(t *testing.T) {
 func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithoutLifeCycle(t *testing.T) {
 	assert := assert.New(t)
 	annotationsDriver = getAnnotationsService(t, v2PlatformVersion)
-    defer cleanDB( t, assert)
+	defer cleanDB(t, assert)
 	contentQuery := &neoism.CypherQuery{
 		Statement: `MERGE (n:Thing {uuid:{contentUuid}}) SET n :Thing
 		MERGE (b:Brand{uuid:{brandUuid}}) SET b :Concept:Thing
@@ -198,11 +198,10 @@ func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithoutLifeCy
 	assert.NotEmpty(result)
 }
 
-
 func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithContentLifeCycle(t *testing.T) {
 	assert := assert.New(t)
 	annotationsDriver = getAnnotationsService(t, v2PlatformVersion)
-    //defer cleanDB( t, assert)
+	//defer cleanDB( t, assert)
 	contentQuery := &neoism.CypherQuery{
 		Statement: `MERGE (n:Thing {uuid:{contentUuid}}) SET n :Thing
 		MERGE (b:Brand{uuid:{brandUuid}}) SET b :Concept:Thing
@@ -211,11 +210,11 @@ func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithContentLi
 			"contentUuid":     contentUUID,
 			"brandUuid":       brandUUID,
 			"platformVersion": v2PlatformVersion,
-			"lifecycle": contentLifecyle,
+			"lifecycle":       contentLifecyle,
 		},
 	}
 
-	err :=annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{contentQuery})
+	err := annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{contentQuery})
 	assert.NoError(err, "Error c for content uuid %s", contentUUID)
 
 	annotationsToWrite := annotations{annotation{
@@ -259,7 +258,7 @@ func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithContentLi
 	readErr := annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{getContentQuery})
 	assert.NoError(readErr)
 	assert.NotEmpty(result)
-	
+
 	removeRelationshipQuery := &neoism.CypherQuery{
 		Statement: `
 			MATCH (b:Thing {uuid:{brandUuid}})<-[rel:IS_CLASSIFIED_BY]-(t:Thing)
@@ -275,7 +274,6 @@ func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithContentLi
 	err = deleteNode(annotationsDriver, brandUUID)
 	assert.NoError(err, "Error trying to delete concept node with uuid %s, err=%v", brandUUID, err)
 }
-
 
 func TestWriteDoesRemoveExistingIsClassifedForV1TermsAndTheirRelationships(t *testing.T) {
 	assert := assert.New(t)
@@ -309,7 +307,7 @@ func TestWriteDoesRemoveExistingIsClassifedForV1TermsAndTheirRelationships(t *te
 	err := annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{contentQuery})
 	assert.NoError(err, "Error writing annotations for content uuid %s", contentUUID)
 
-	 annotationsToWrite := annotations{annotation{
+	annotationsToWrite := annotations{annotation{
 		Thing: thing{ID: getURI(conceptUUID),
 			PrefLabel: "prefLabel",
 			Types: []string{
@@ -690,7 +688,7 @@ func writeClassifedByRelationship(db *neoism.Database, contentId string, concept
                 MERGE (content:Thing{uuid:{contentId}})
                 MERGE (upp:Identifier:UPPIdentifier{value:{conceptId}})
                 MERGE (upp)-[:IDENTIFIES]->(concept:Thing) ON CREATE SET concept.uuid = {conceptId}
-                MERGE (content)-[pred:IS_CLASSIFIED_BY {platformVersion:'v1'}]->(concept)              
+                MERGE (content)-[pred:IS_CLASSIFIED_BY {platformVersion:'v1'}]->(concept)
           `
 		qs = []*neoism.CypherQuery{
 			{
@@ -738,8 +736,6 @@ func checkClassifedByRelationship(db *neoism.Database, conceptId string, lifecyc
 	return results[0].Count
 }
 
-
-
 func cleanUp(t *testing.T, contentUUID string, conceptUUIDs []string) {
 	assert := assert.New(t)
 	found, err := annotationsDriver.Delete(contentUUID)
@@ -754,7 +750,6 @@ func cleanUp(t *testing.T, contentUUID string, conceptUUIDs []string) {
 		assert.NoError(err, "Could not delete concept node")
 	}
 }
-
 
 /*func checkDbClean(db *neoism.Database, t *testing.T) {
 	assert := assert.New(t)
@@ -777,8 +772,7 @@ func cleanUp(t *testing.T, contentUUID string, conceptUUIDs []string) {
 	assert.Empty(result)
 }*/
 
-
-func cleanDB( t *testing.T, assert *assert.Assertions) {
+func cleanDB(t *testing.T, assert *assert.Assertions) {
 	annotationsDriver = getAnnotationsService(t, v2PlatformVersion)
 	qs := []*neoism.CypherQuery{
 		{
@@ -798,12 +792,9 @@ func cleanDB( t *testing.T, assert *assert.Assertions) {
 		},
 	}
 
-	err :=  annotationsDriver.cypherRunner.CypherBatch(qs)
+	err := annotationsDriver.cypherRunner.CypherBatch(qs)
 	assert.NoError(err)
 }
-
-
-
 
 func deleteNode(annotationsDriver service, uuid string) error {
 

--- a/annotations/cypher_test.go
+++ b/annotations/cypher_test.go
@@ -737,27 +737,6 @@ func cleanUp(t *testing.T, contentUUID string, conceptUUIDs []string) {
 	}
 }
 
-/*func checkDbClean(db *neoism.Database, t *testing.T) {
-	assert := assert.New(t)
-
-	result := []struct {
-		Uuid string `json:"org.uuid"`
-	}{}
-
-	checkGraph := neoism.CypherQuery{
-		Statement: `
-			MATCH (org:Thing) WHERE org.uuid in {uuids} RETURN org.uuid
-		`,
-		Parameters: neoism.Props{
-			"uuids": []string{fullContentUuid, minimalContentUuid},
-		},
-		Result: &result,
-	}
-	err := db.Cypher(&checkGraph)
-	assert.NoError(err)
-	assert.Empty(result)
-}*/
-
 func cleanDB(t *testing.T, assert *assert.Assertions) {
 	annotationsDriver = getAnnotationsService(t, v2PlatformVersion)
 	qs := []*neoism.CypherQuery{

--- a/annotations/cypher_test.go
+++ b/annotations/cypher_test.go
@@ -344,9 +344,12 @@ func getAnnotationsService(t *testing.T, platformVersion string) service {
 		url = "http://localhost:7474/db/data"
 	}
 
-	db, err := neoism.Connect(url)
+
+	conf := neoutils.DefaultConnectionConfig()
+	conf.Transactional = false
+	db, err := neoutils.Connect(url, conf)
 	assert.NoError(err, "Failed to connect to Neo4j")
-	return NewAnnotationsService(neoutils.StringerDb{db}, db, platformVersion)
+	return NewCypherAnnotationsService(db, platformVersion)
 }
 
 func readAnnotationsForContentUUIDAndCheckKeyFieldsMatch(t *testing.T, contentUUID string, expectedAnnotations []annotation) {

--- a/annotations/cypher_test.go
+++ b/annotations/cypher_test.go
@@ -20,7 +20,7 @@ const (
 	brandUUID         = "8e21cbd4-e94b-497a-a43b-5b2309badeb3"
 	v2PlatformVersion = "v2"
 	v1PlatformVersion = "v1"
-	contentLifecyle   = "content"
+	contentLifecycle = "content"
 	annotationsV2     = "annotations-v2"
 )
 
@@ -135,7 +135,7 @@ func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithContentLi
 			"contentUuid":     contentUUID,
 			"brandUuid":       brandUUID,
 			"platformVersion": v2PlatformVersion,
-			"lifecycle":       contentLifecyle,
+			"lifecycle":       contentLifecycle,
 
 		},
 	}
@@ -349,6 +349,7 @@ func getAnnotationsService(t *testing.T, platformVersion string) service {
 	conf.Transactional = false
 	db, err := neoutils.Connect(url, conf)
 	assert.NoError(err, "Failed to connect to Neo4j")
+
 	return NewCypherAnnotationsService(db, platformVersion)
 }
 

--- a/annotations/cypher_test.go
+++ b/annotations/cypher_test.go
@@ -55,7 +55,6 @@ func TestDeleteRemovesAnnotationsButNotConceptsOrContent(t *testing.T) {
 	assert.NoError(annotationsDriver.Write(contentUUID, annotationsToDelete), "Failed to write annotation")
 
 	readAnnotationsForContentUUIDAndCheckKeyFieldsMatch(t, contentUUID, annotationsToDelete)
-	checkRelationship(assert, contentUUID, "v2")
 
 	deleted, err := annotationsDriver.Delete(contentUUID)
 	assert.True(deleted, "Didn't manage to delete annotations for content uuid %s", contentUUID)
@@ -177,6 +176,8 @@ func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithoutLifeCy
 	}}
 
 	assert.NoError(annotationsDriver.Write(contentUUID, annotationsToWrite), "Failed to write annotation")
+	checkRelationship(assert, contentUUID, "v2")
+
 	deleted, err := annotationsDriver.Delete(contentUUID)
 	assert.True(deleted, "Didn't manage to delete annotations for content uuid %s", contentUUID)
 	assert.NoError(err, "Error deleting annotations for content uuid %s", contentUUID)

--- a/annotations/cypher_test.go
+++ b/annotations/cypher_test.go
@@ -411,7 +411,7 @@ func checkConceptNodeIsStillPresent(uuid string, t *testing.T) {
 	assert.Equal(uuid, results[0].UUID, "Did not find correct node")
 }
 
-func writeClassifedByRelationship(db *neoism.Database, contentId string, conceptId string, lifecycle string, t *testing.T, assert *assert.Assertions) {
+func writeClassifedByRelationship(db neoutils.CypherRunner, contentId string, conceptId string, lifecycle string, t *testing.T, assert *assert.Assertions) {
 
 	var annotateQuery string
 	var qs []*neoism.CypherQuery


### PR DESCRIPTION
We had to apply changes for the lifecycle to a previous version of annotations-rw as we couldn't apply those changes on top of the version that had the new UPPIdentifiers because we still haven't loaded all the new UPPIdentifiers. So this PR might be slightly confusing as some functionality has been released but re-applied:

This pull request has several aspects: 
1. Handling of new UPPIdentifiers for Things (unknown concepts)
2. Annotation relationships managed by the annotations-rw (either v1 or v2) now have a new lifecycle property which indicates whether the relationship was created by the annotations-rw or the content-rw (i.e. Brands).  (This is already live)
3. Use the New Neoutils