### PR TITLE
Adding changes for lifecycle.

### DIFF
--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -159,9 +159,9 @@ func (s service) Count() (int, error) {
 
 	query := &neoism.CypherQuery{
 		Statement: `MATCH ()-[r{platformVersion:{platformVersion}}]->()
-								 WHERE r.lifecycle = {lifecycle}
-								 OR r.lifecycle IS NULL
-								 RETURN count(r) as c`,
+                WHERE r.lifecycle = {lifecycle}
+                OR r.lifecycle IS NULL
+                RETURN count(r) as c`,
 		Parameters: neoism.Props{"platformVersion": s.platformVersion, "lifecycle": "annotations-" + s.platformVersion},
 		Result:     &results,
 	}
@@ -181,11 +181,11 @@ func (s service) Initialise() error {
 
 func createAnnotationRelationship(relation string) (statement string) {
 	stmt := `
-                MERGE (content:Thing{uuid:{contentID}})
-                MERGE (concept:Thing{uuid:{conceptID}})
-                MERGE (content)-[pred:%s{platformVersion:{platformVersion}}]->(concept)
-                SET pred={annProps}
-                `
+            MERGE (content:Thing{uuid:{contentID}})
+            MERGE (concept:Thing{uuid:{conceptID}})
+            MERGE (content)-[pred:%s{platformVersion:{platformVersion}}]->(concept)
+            SET pred={annProps}
+          `
 	statement = fmt.Sprintf(stmt, relation)
 	return statement
 }
@@ -309,16 +309,16 @@ func dropAllAnnotationsQuery(contentUUID string, platformVersion string) *neoism
 	var matchStmtTemplate string
 
 	// TODO hard-coded verification:
-	// WE STILL NEED THIS UNTIL EVERYTHNG HAS A LIFECYCLE PROPERTY!
+	// WE STILL NEED THIS UNTIL EVERYTHING HAS A LIFECYCLE PROPERTY!
 	// -> necessary for brands - which got written by content-api with isClassifiedBy relationship, and should not be deleted by annotations-rw
 	// -> so far brands are the only v2 concepts which have isClassifiedBy relationship; as soon as this changes: implementation needs to be updated
 	if platformVersion == "v2" {
 		matchStmtTemplate = `OPTIONAL MATCH (:Thing{uuid:{contentID}})-[r:MENTIONS{platformVersion:{platformVersion}}]->(t:Thing)
-                        DELETE r`
+                         DELETE r`
 	} else {
 		matchStmtTemplate = `OPTIONAL MATCH (:Thing{uuid:{contentID}})-[r]->(t:Thing)
-			WHERE r.platformVersion={platformVersion}
-                        DELETE r`
+                         WHERE r.platformVersion={platformVersion}
+                         DELETE r`
 	}
 
 	query := neoism.CypherQuery{}

--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -110,12 +110,7 @@ func (s service) Delete(contentUUID string) (bool, error) {
 		return false, err
 	}
 
-	var found bool
-	if stats.ContainsUpdates {
-		found = true
-	}
-
-	return found, err
+	return stats.ContainsUpdates, err
 }
 
 //Write a set of annotations associated with a piece of content. Any annotations
@@ -163,8 +158,11 @@ func (s service) Count() (int, error) {
 	}{}
 
 	query := &neoism.CypherQuery{
-		Statement:  `MATCH ()-[r{platformVersion:{platformVersion}}]->() RETURN count(r) as c`,
-		Parameters: neoism.Props{"platformVersion": s.platformVersion},
+		Statement: `MATCH ()-[r{platformVersion:{platformVersion}}]->()
+								 WHERE r.lifecycle = {lifecycle}
+								 OR r.lifecycle IS NULL
+								 RETURN count(r) as c`,
+		Parameters: neoism.Props{"platformVersion": s.platformVersion, "lifecycle": "annotations-" + s.platformVersion},
 		Result:     &results,
 	}
 
@@ -216,6 +214,7 @@ func createAnnotationQuery(contentUUID string, ann annotation, platformVersion s
 	var prov provenance
 	params := map[string]interface{}{}
 	params["platformVersion"] = platformVersion
+	params["lifecycle"] = "annotations-" + platformVersion
 
 	if len(ann.Provenances) >= 1 {
 		prov = ann.Provenances[0]
@@ -309,7 +308,8 @@ func dropAllAnnotationsQuery(contentUUID string, platformVersion string) *neoism
 
 	var matchStmtTemplate string
 
-	//TODO hard-coded verification:
+	// TODO hard-coded verification:
+	// WE STILL NEED THIS UNTIL EVERYTHNG HAS A LIFECYCLE PROPERTY!
 	// -> necessary for brands - which got written by content-api with isClassifiedBy relationship, and should not be deleted by annotations-rw
 	// -> so far brands are the only v2 concepts which have isClassifiedBy relationship; as soon as this changes: implementation needs to be updated
 	if platformVersion == "v2" {

--- a/annotations/cypher_test.go
+++ b/annotations/cypher_test.go
@@ -168,7 +168,7 @@ func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithContentLi
 	assert.NotEmpty(result)
 }
 
-func TestWriteDoesRemoveExistingIsClassifedForV1TermsAndTheirRelationships(t *testing.T) {
+func TestWriteDoesRemoveExistingIsClassifiedForV1TermsAndTheirRelationships(t *testing.T) {
 	assert := assert.New(t)
 
 	v1AnnotationsDriver := getAnnotationsService(t, v1PlatformVersion)

--- a/annotations/cypher_test.go
+++ b/annotations/cypher_test.go
@@ -84,7 +84,7 @@ func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithoutLifecy
 	annotationsDriver = getAnnotationsService(t, v2PlatformVersion)
 	defer cleanDB(t, assert)
 
-	contentQuery := &neoism.CypherQuery{
+	testSetupQuery := &neoism.CypherQuery{
 		Statement: `MERGE (n:Thing {uuid:{contentUuid}}) SET n :Thing
 		MERGE (b:Brand{uuid:{brandUuid}}) SET b :Concept:Thing
 		CREATE (n)-[rel:IS_CLASSIFIED_BY{platformVersion:{platformVersion}}]->(b)`,
@@ -95,7 +95,7 @@ func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithoutLifecy
 		},
 	}
 
-	err := annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{contentQuery})
+	err := annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{testSetupQuery})
 	annotationsToWrite := exampleConcepts(conceptUUID)
 
 	assert.NoError(annotationsDriver.Write(contentUUID, annotationsToWrite), "Failed to write annotation")

--- a/annotations/cypher_test.go
+++ b/annotations/cypher_test.go
@@ -14,12 +14,14 @@ var annotationsDriver service
 
 const (
 	contentUUID       = "32b089d2-2aae-403d-be6e-877404f586cf"
-	conceptUUID       = "412e4ca3-f8d5-4456-8606-064c1dba3c45"
+	conceptUUID       = "a7732a22-3884-4bfe-9761-fef161e41d69"
 	secondConceptUUID = "c834adfa-10c9-4748-8a21-c08537172706"
 	oldConceptUUID    = "ad28ddc7-4743-4ed3-9fad-5012b61fb919"
 	brandUUID         = "8e21cbd4-e94b-497a-a43b-5b2309badeb3"
 	v2PlatformVersion = "v2"
 	v1PlatformVersion = "v1"
+	contentLifecycle  = "content"
+	annotationsV2     = "annotations-v2"
 )
 
 func getURI(uuid string) string {
@@ -137,33 +139,16 @@ func TestWriteAllValuesPresent(t *testing.T) {
 	cleanUp(t, contentUUID, []string{conceptUUID})
 }
 
-func TestWriteDoesNotRemoveExistingIsClassifedByBrandRelationships(t *testing.T) {
+func TestWriteDoesNotRemoveExistingIsClassifedByBrandRelationshipsWithoutLifecycle(t *testing.T) {
 	assert := assert.New(t)
 
 	annotationsDriver = getAnnotationsService(t, v2PlatformVersion)
-
-	createBrandQuery := &neoism.CypherQuery{
-		Statement: `MERGE (b:Brand{uuid:{brandUuid}}) SET b :Concept:Thing RETURN b.uuid`,
-		Parameters: map[string]interface{}{
-			"brandUuid": brandUUID,
-		},
-	}
-
-	annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{createBrandQuery})
-
-	createContentQuery := &neoism.CypherQuery{
-		Statement: `MERGE (c:Content{uuid:{contentUuid}}) SET c :Thing RETURN c.uuid`,
-		Parameters: map[string]interface{}{
-			"contentUuid": contentUUID,
-		},
-	}
-
-	annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{createContentQuery})
+	defer cleanDB(t, assert)
 
 	contentQuery := &neoism.CypherQuery{
-		Statement: `MERGE (n:Thing {uuid:{contentUuid}})
-		MERGE (b:Brand{uuid:{brandUuid}})
-		CREATE (n)-[rel:IS_CLASSIFIED_BY{platformVersion:{platformVersion}}]->(b) RETURN rel.platformVersion`,
+		Statement: `MERGE (n:Thing {uuid:{contentUuid}}) SET n :Thing
+		MERGE (b:Brand{uuid:{brandUuid}}) SET b :Concept:Thing
+		CREATE (n)-[rel:IS_CLASSIFIED_BY{platformVersion:{platformVersion}}]->(b)`,
 		Parameters: map[string]interface{}{
 			"contentUuid":     contentUUID,
 			"brandUuid":       brandUUID,
@@ -194,8 +179,74 @@ func TestWriteDoesNotRemoveExistingIsClassifedByBrandRelationships(t *testing.T)
 	}}
 
 	assert.NoError(annotationsDriver.Write(contentUUID, annotationsToWrite), "Failed to write annotation")
-	found, err := annotationsDriver.Delete(contentUUID)
-	assert.True(found, "Didn't manage to delete annotations for content uuid %s", contentUUID)
+	checkRelationship(assert, contentUUID, "v2")
+
+	deleted, err := annotationsDriver.Delete(contentUUID)
+	assert.True(deleted, "Didn't manage to delete annotations for content uuid %s", contentUUID)
+	assert.NoError(err, "Error deleting annotations for content uuid %s", contentUUID)
+
+	result := []struct {
+		UUID string `json:"b.uuid"`
+	}{}
+
+	getContentQuery := &neoism.CypherQuery{
+		Statement: `MATCH (n:Thing {uuid:{contentUuid}})-[:IS_CLASSIFIED_BY]->(b:Brand) RETURN b.uuid`,
+		Parameters: map[string]interface{}{
+			"contentUuid": contentUUID,
+			"brandUuid":   brandUUID,
+		},
+		Result: &result,
+	}
+
+	readErr := annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{getContentQuery})
+	assert.NoError(readErr)
+	assert.NotEmpty(result)
+}
+
+func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithContentLifeCycle(t *testing.T) {
+	assert := assert.New(t)
+	annotationsDriver = getAnnotationsService(t, v2PlatformVersion)
+	defer cleanDB(t, assert)
+	contentQuery := &neoism.CypherQuery{
+		Statement: `MERGE (n:Thing {uuid:{contentUuid}}) SET n :Thing
+		MERGE (b:Brand{uuid:{brandUuid}}) SET b :Concept:Thing
+		CREATE (n)-[rel:IS_CLASSIFIED_BY{platformVersion:{platformVersion}, lifecycle: {lifecycle}}]->(b)`,
+		Parameters: map[string]interface{}{
+			"contentUuid":     contentUUID,
+			"brandUuid":       brandUUID,
+			"platformVersion": v2PlatformVersion,
+			"lifecycle":       contentLifecycle,
+		},
+	}
+
+	err := annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{contentQuery})
+	assert.NoError(err, "Error c for content uuid %s", contentUUID)
+
+	annotationsToWrite := annotations{annotation{
+		Thing: thing{ID: getURI(conceptUUID),
+			PrefLabel: "prefLabel",
+			Types: []string{
+				"http://www.ft.com/ontology/organisation/Organisation",
+				"http://www.ft.com/ontology/core/Thing",
+				"http://www.ft.com/ontology/concept/Concept",
+			}},
+		Provenances: []provenance{
+			{
+				Scores: []score{
+					score{ScoringSystem: relevanceScoringSystem, Value: 0.9},
+					score{ScoringSystem: confidenceScoringSystem, Value: 0.8},
+				},
+				AgentRole: "http://api.ft.com/things/0edd3c31-1fd0-4ef6-9230-8d545be3880a",
+				AtTime:    "2016-01-01T19:43:47.314Z",
+			},
+		},
+	}}
+
+	assert.NoError(annotationsDriver.Write(contentUUID, annotationsToWrite), "Failed to write annotation")
+	checkRelationship(assert, contentUUID, "v2")
+
+	deleted, err := annotationsDriver.Delete(contentUUID)
+	assert.True(deleted, "Didn't manage to delete annotations for content uuid %s", contentUUID)
 	assert.NoError(err, "Error deleting annotations for content uuid %s", contentUUID)
 
 	result := []struct {
@@ -214,21 +265,6 @@ func TestWriteDoesNotRemoveExistingIsClassifedByBrandRelationships(t *testing.T)
 	readErr := annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{getContentQuery})
 	assert.NoError(readErr)
 	assert.NotEmpty(result)
-
-	removeRelationshipQuery := &neoism.CypherQuery{
-		Statement: `
-			MATCH (b:Thing {uuid:{brandUuid}})<-[rel:IS_CLASSIFIED_BY]-(t:Thing)
-			DELETE rel
-		`,
-		Parameters: map[string]interface{}{
-			"brandUuid": brandUUID,
-		},
-	}
-
-	annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{removeRelationshipQuery})
-
-	err = deleteNode(annotationsDriver, brandUUID)
-	assert.NoError(err, "Error trying to delete concept node with uuid %s, err=%v", brandUUID, err)
 }
 
 func TestWriteDoesRemoveExistingIsClassifedForV1TermsAndTheirRelationships(t *testing.T) {
@@ -588,6 +624,25 @@ func readAnnotationsForContentUUIDAndCheckKeyFieldsMatch(t *testing.T, contentUU
 	}
 }
 
+func checkRelationship(assert *assert.Assertions, contentID string, platformVersion string) {
+	countQuery := `Match (t:Thing {uuid: {contentID}})-[r {lifecycle: {lifecycle}}]-(x) return count(r) as c`
+
+	results := []struct {
+		Count int `json:"c"`
+	}{}
+
+	qs := &neoism.CypherQuery{
+		Statement:  countQuery,
+		Parameters: neoism.Props{"contentID": contentID, "lifecycle": "annotations-" + platformVersion},
+		Result:     &results,
+	}
+
+	err := annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{qs})
+	assert.NoError(err)
+	assert.Equal(1, len(results), "More results found than expected!")
+	assert.Equal(1, results[0].Count, "No Relationship with Lifecycle found!")
+}
+
 func checkNodeIsStillPresent(uuid string, t *testing.T) {
 	assert := assert.New(t)
 	annotationsDriver = getAnnotationsService(t, v2PlatformVersion)
@@ -623,6 +678,30 @@ func cleanUp(t *testing.T, contentUUID string, conceptUUIDs []string) {
 		err = deleteNode(annotationsDriver, conceptUUID)
 		assert.NoError(err, "Could not delete concept node")
 	}
+}
+
+func cleanDB(t *testing.T, assert *assert.Assertions) {
+	annotationsDriver = getAnnotationsService(t, v2PlatformVersion)
+	qs := []*neoism.CypherQuery{
+		{
+			Statement: fmt.Sprintf("MATCH (mc:Thing {uuid: '%v'}) DETACH DELETE mc", contentUUID),
+		},
+		{
+			Statement: fmt.Sprintf("MATCH (fc:Thing {uuid: '%v'}) DETACH DELETE fc", conceptUUID),
+		},
+		{
+			Statement: fmt.Sprintf("MATCH (fc:Thing {uuid: '%v'}) DETACH DELETE fc", secondConceptUUID),
+		},
+		{
+			Statement: fmt.Sprintf("MATCH (fc:Thing {uuid: '%v'}) DETACH DELETE fc", oldConceptUUID),
+		},
+		{
+			Statement: fmt.Sprintf("MATCH (fc:Thing {uuid: '%v'}) DETACH DELETE fc", brandUUID),
+		},
+	}
+
+	err := annotationsDriver.cypherRunner.CypherBatch(qs)
+	assert.NoError(err)
 }
 
 func deleteNode(annotationsDriver service, uuid string) error {

--- a/annotations/cypher_test.go
+++ b/annotations/cypher_test.go
@@ -30,31 +30,10 @@ func getURI(uuid string) string {
 
 func TestDeleteRemovesAnnotationsButNotConceptsOrContent(t *testing.T) {
 	assert := assert.New(t)
-
 	annotationsDriver = getAnnotationsService(t, v2PlatformVersion)
-
-	annotationsToDelete := annotations{annotation{
-		Thing: thing{ID: getURI(conceptUUID),
-			PrefLabel: "prefLabel",
-			Types: []string{
-				"http://www.ft.com/ontology/organisation/Organisation",
-				"http://www.ft.com/ontology/core/Thing",
-				"http://www.ft.com/ontology/concept/Concept",
-			}},
-		Provenances: []provenance{
-			{
-				Scores: []score{
-					score{ScoringSystem: relevanceScoringSystem, Value: 0.9},
-					score{ScoringSystem: confidenceScoringSystem, Value: 0.8},
-				},
-				AgentRole: "http://api.ft.com/things/0edd3c31-1fd0-4ef6-9230-8d545be3880a",
-				AtTime:    "2016-01-01T19:43:47.314Z",
-			},
-		},
-	}}
+	annotationsToDelete := exampleConcepts(conceptUUID)
 
 	assert.NoError(annotationsDriver.Write(contentUUID, annotationsToDelete), "Failed to write annotation")
-
 	readAnnotationsForContentUUIDAndCheckKeyFieldsMatch(t, contentUUID, annotationsToDelete)
 
 	found, err := annotationsDriver.Delete(contentUUID)
@@ -74,7 +53,6 @@ func TestDeleteRemovesAnnotationsButNotConceptsOrContent(t *testing.T) {
 	assert.NoError(err, "Error trying to delete content node with uuid %s, err=%v", contentUUID, err)
 	err = deleteNode(annotationsDriver, conceptUUID)
 	assert.NoError(err, "Error trying to delete concept node with uuid %s, err=%v", conceptUUID, err)
-
 }
 
 func TestWriteFailsWhenNoConceptIDSupplied(t *testing.T) {
@@ -82,26 +60,7 @@ func TestWriteFailsWhenNoConceptIDSupplied(t *testing.T) {
 
 	annotationsDriver = getAnnotationsService(t, v2PlatformVersion)
 
-	annotationsToWrite := annotations{annotation{
-		Thing: thing{PrefLabel: "prefLabel",
-			Types: []string{
-				"http://www.ft.com/ontology/organisation/Organisation",
-				"http://www.ft.com/ontology/core/Thing",
-				"http://www.ft.com/ontology/concept/Concept",
-			}},
-		Provenances: []provenance{
-			{
-				Scores: []score{
-					score{ScoringSystem: relevanceScoringSystem, Value: 0.9},
-					score{ScoringSystem: confidenceScoringSystem, Value: 0.8},
-				},
-				AgentRole: "http://api.ft.com/things/0edd3c31-1fd0-4ef6-9230-8d545be3880a",
-				AtTime:    "2016-01-01T19:43:47.314Z",
-			},
-		},
-	}}
-
-	err := annotationsDriver.Write(contentUUID, annotationsToWrite)
+	err := annotationsDriver.Write(contentUUID, conceptWithoutID)
 	assert.Error(err, "Should have failed to write annotation")
 	_, ok := err.(ValidationError)
 	assert.True(ok, "Should have returned a validation error")
@@ -109,28 +68,8 @@ func TestWriteFailsWhenNoConceptIDSupplied(t *testing.T) {
 
 func TestWriteAllValuesPresent(t *testing.T) {
 	assert := assert.New(t)
-
 	annotationsDriver = getAnnotationsService(t, v2PlatformVersion)
-
-	annotationsToWrite := annotations{annotation{
-		Thing: thing{ID: getURI(conceptUUID),
-			PrefLabel: "prefLabel",
-			Types: []string{
-				"http://www.ft.com/ontology/organisation/Organisation",
-				"http://www.ft.com/ontology/core/Thing",
-				"http://www.ft.com/ontology/concept/Concept",
-			}},
-		Provenances: []provenance{
-			{
-				Scores: []score{
-					score{ScoringSystem: relevanceScoringSystem, Value: 0.9},
-					score{ScoringSystem: confidenceScoringSystem, Value: 0.8},
-				},
-				AgentRole: "http://api.ft.com/things/0edd3c31-1fd0-4ef6-9230-8d545be3880a",
-				AtTime:    "2016-01-01T19:43:47.314Z",
-			},
-		},
-	}}
+	annotationsToWrite := exampleConcepts(conceptUUID)
 
 	assert.NoError(annotationsDriver.Write(contentUUID, annotationsToWrite), "Failed to write annotation")
 
@@ -139,7 +78,7 @@ func TestWriteAllValuesPresent(t *testing.T) {
 	cleanUp(t, contentUUID, []string{conceptUUID})
 }
 
-func TestWriteDoesNotRemoveExistingIsClassifedByBrandRelationshipsWithoutLifecycle(t *testing.T) {
+func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithoutLifecycle(t *testing.T) {
 	assert := assert.New(t)
 
 	annotationsDriver = getAnnotationsService(t, v2PlatformVersion)
@@ -157,26 +96,7 @@ func TestWriteDoesNotRemoveExistingIsClassifedByBrandRelationshipsWithoutLifecyc
 	}
 
 	err := annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{contentQuery})
-
-	annotationsToWrite := annotations{annotation{
-		Thing: thing{ID: getURI(conceptUUID),
-			PrefLabel: "prefLabel",
-			Types: []string{
-				"http://www.ft.com/ontology/organisation/Organisation",
-				"http://www.ft.com/ontology/core/Thing",
-				"http://www.ft.com/ontology/concept/Concept",
-			}},
-		Provenances: []provenance{
-			{
-				Scores: []score{
-					score{ScoringSystem: relevanceScoringSystem, Value: 0.9},
-					score{ScoringSystem: confidenceScoringSystem, Value: 0.8},
-				},
-				AgentRole: "http://api.ft.com/things/0edd3c31-1fd0-4ef6-9230-8d545be3880a",
-				AtTime:    "2016-01-01T19:43:47.314Z",
-			},
-		},
-	}}
+	annotationsToWrite := exampleConcepts(conceptUUID)
 
 	assert.NoError(annotationsDriver.Write(contentUUID, annotationsToWrite), "Failed to write annotation")
 	checkRelationship(assert, contentUUID, "v2")
@@ -221,26 +141,7 @@ func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithContentLi
 
 	err := annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{contentQuery})
 	assert.NoError(err, "Error c for content uuid %s", contentUUID)
-
-	annotationsToWrite := annotations{annotation{
-		Thing: thing{ID: getURI(conceptUUID),
-			PrefLabel: "prefLabel",
-			Types: []string{
-				"http://www.ft.com/ontology/organisation/Organisation",
-				"http://www.ft.com/ontology/core/Thing",
-				"http://www.ft.com/ontology/concept/Concept",
-			}},
-		Provenances: []provenance{
-			{
-				Scores: []score{
-					score{ScoringSystem: relevanceScoringSystem, Value: 0.9},
-					score{ScoringSystem: confidenceScoringSystem, Value: 0.8},
-				},
-				AgentRole: "http://api.ft.com/things/0edd3c31-1fd0-4ef6-9230-8d545be3880a",
-				AtTime:    "2016-01-01T19:43:47.314Z",
-			},
-		},
-	}}
+	annotationsToWrite := exampleConcepts(conceptUUID)
 
 	assert.NoError(annotationsDriver.Write(contentUUID, annotationsToWrite), "Failed to write annotation")
 	checkRelationship(assert, contentUUID, "v2")
@@ -296,28 +197,7 @@ func TestWriteDoesRemoveExistingIsClassifedForV1TermsAndTheirRelationships(t *te
 	}
 
 	err := annotationsDriver.cypherRunner.CypherBatch([]*neoism.CypherQuery{contentQuery})
-
-	annotationsToWrite := annotations{annotation{
-		Thing: thing{ID: getURI(conceptUUID),
-			PrefLabel: "prefLabel",
-			Types: []string{
-				"http://www.ft.com/ontology/organisation/Organisation",
-				"http://www.ft.com/ontology/core/Thing",
-				"http://www.ft.com/ontology/concept/Concept",
-			}},
-		Provenances: []provenance{
-			{
-				Scores: []score{
-					score{ScoringSystem: relevanceScoringSystem, Value: 0.9},
-					score{ScoringSystem: confidenceScoringSystem, Value: 0.8},
-				},
-				AgentRole: "http://api.ft.com/things/0edd3c31-1fd0-4ef6-9230-8d545be3880a",
-				AtTime:    "2016-01-01T19:43:47.314Z",
-			},
-		},
-	}}
-
-	assert.NoError(v1AnnotationsDriver.Write(contentUUID, annotationsToWrite), "Failed to write annotation")
+	assert.NoError(v1AnnotationsDriver.Write(contentUUID, exampleConcepts(conceptUUID)), "Failed to write annotation")
 	found, err := v1AnnotationsDriver.Delete(contentUUID)
 	assert.True(found, "Didn't manage to delete annotations for content uuid %s", contentUUID)
 	assert.NoError(err, "Error deleting annotations for content uuid %s", contentUUID)
@@ -376,133 +256,31 @@ func TestWriteDoesRemoveExistingIsClassifedForV1TermsAndTheirRelationships(t *te
 
 func TestWriteAndReadMultipleAnnotations(t *testing.T) {
 	assert := assert.New(t)
-
 	annotationsDriver = getAnnotationsService(t, v2PlatformVersion)
+	assert.NoError(annotationsDriver.Write(contentUUID, multiConceptAnnotations), "Failed to write annotation")
 
-	annotationsToWrite := annotations{annotation{
-		Thing: thing{ID: getURI(conceptUUID),
-			PrefLabel: "prefLabel",
-			Types: []string{
-				"http://www.ft.com/ontology/organisation/Organisation",
-				"http://www.ft.com/ontology/core/Thing",
-				"http://www.ft.com/ontology/concept/Concept",
-			}},
-		Provenances: []provenance{
-			{
-				Scores: []score{
-					score{ScoringSystem: relevanceScoringSystem, Value: 0.9},
-					score{ScoringSystem: confidenceScoringSystem, Value: 0.8},
-				},
-				AgentRole: "http://api.ft.com/things/0edd3c31-1fd0-4ef6-9230-8d545be3880a",
-				AtTime:    "2016-01-01T19:43:47.314Z",
-			},
-		},
-	}, annotation{
-		Thing: thing{ID: getURI(secondConceptUUID),
-			PrefLabel: "prefLabel",
-			Types: []string{
-				"http://www.ft.com/ontology/organisation/Organisation",
-				"http://www.ft.com/ontology/core/Thing",
-				"http://www.ft.com/ontology/concept/Concept",
-			}},
-		Provenances: []provenance{
-			{
-				Scores: []score{
-					score{ScoringSystem: relevanceScoringSystem, Value: 0.4},
-					score{ScoringSystem: confidenceScoringSystem, Value: 0.5},
-				},
-				AgentRole: "http://api.ft.com/things/0edd3c31-1fd0-4ef6-9230-8d545be3880a",
-				AtTime:    "2016-01-01T19:43:47.314Z",
-			},
-		},
-	}}
-
-	assert.NoError(annotationsDriver.Write(contentUUID, annotationsToWrite), "Failed to write annotation")
-
-	readAnnotationsForContentUUIDAndCheckKeyFieldsMatch(t, contentUUID, annotationsToWrite)
-
+	readAnnotationsForContentUUIDAndCheckKeyFieldsMatch(t, contentUUID, multiConceptAnnotations)
 	cleanUp(t, contentUUID, []string{conceptUUID, secondConceptUUID})
 }
 
 func TestIfProvenanceGetsWrittenWithEmptyAgentRoleAndTimeValues(t *testing.T) {
 	assert := assert.New(t)
-
 	annotationsDriver = getAnnotationsService(t, v2PlatformVersion)
 
-	annotationsToWrite := annotations{annotation{
-		Thing: thing{ID: getURI(conceptUUID),
-			PrefLabel: "prefLabel",
-			Types: []string{
-				"http://www.ft.com/ontology/organisation/Organisation",
-				"http://www.ft.com/ontology/core/Thing",
-				"http://www.ft.com/ontology/concept/Concept",
-			}},
-		Provenances: []provenance{
-			{
-				Scores: []score{
-					score{ScoringSystem: relevanceScoringSystem, Value: 0.9},
-					score{ScoringSystem: confidenceScoringSystem, Value: 0.8},
-				},
-				AgentRole: "",
-				AtTime:    "",
-			},
-		},
-	}}
-
-	assert.NoError(annotationsDriver.Write(contentUUID, annotationsToWrite), "Failed to write annotation")
-
-	readAnnotationsForContentUUIDAndCheckKeyFieldsMatch(t, contentUUID, annotationsToWrite)
-
+	assert.NoError(annotationsDriver.Write(contentUUID, conceptWithoutAgent), "Failed to write annotation")
+	readAnnotationsForContentUUIDAndCheckKeyFieldsMatch(t, contentUUID, conceptWithoutAgent)
 	cleanUp(t, contentUUID, []string{conceptUUID})
 }
 
 func TestUpdateWillRemovePreviousAnnotations(t *testing.T) {
 	assert := assert.New(t)
-
 	annotationsDriver = getAnnotationsService(t, v2PlatformVersion)
-
-	oldAnnotationsToWrite := annotations{annotation{
-		Thing: thing{ID: getURI(oldConceptUUID),
-			PrefLabel: "prefLabel",
-			Types: []string{
-				"http://www.ft.com/ontology/organisation/Organisation",
-				"http://www.ft.com/ontology/core/Thing",
-				"http://www.ft.com/ontology/concept/Concept",
-			}},
-		Provenances: []provenance{
-			{
-				Scores: []score{
-					score{ScoringSystem: relevanceScoringSystem, Value: 0.9},
-					score{ScoringSystem: confidenceScoringSystem, Value: 0.8},
-				},
-				AgentRole: "http://api.ft.com/things/0edd3c31-1fd0-4ef6-9230-8d545be3880a",
-				AtTime:    "2016-01-01T19:43:47.314Z",
-			},
-		},
-	}}
+	oldAnnotationsToWrite := exampleConcepts(oldConceptUUID)
 
 	assert.NoError(annotationsDriver.Write(contentUUID, oldAnnotationsToWrite), "Failed to write annotations")
 	readAnnotationsForContentUUIDAndCheckKeyFieldsMatch(t, contentUUID, oldAnnotationsToWrite)
 
-	updatedAnnotationsToWrite := annotations{annotation{
-		Thing: thing{ID: getURI(conceptUUID),
-			PrefLabel: "prefLabel",
-			Types: []string{
-				"http://www.ft.com/ontology/organisation/Organisation",
-				"http://www.ft.com/ontology/core/Thing",
-				"http://www.ft.com/ontology/concept/Concept",
-			}},
-		Provenances: []provenance{
-			{
-				Scores: []score{
-					score{ScoringSystem: relevanceScoringSystem, Value: 0.9},
-					score{ScoringSystem: confidenceScoringSystem, Value: 0.8},
-				},
-				AgentRole: "http://api.ft.com/things/0edd3c31-1fd0-4ef6-9230-8d545be3880a",
-				AtTime:    "2016-01-01T19:43:47.314Z",
-			},
-		},
-	}}
+	updatedAnnotationsToWrite := exampleConcepts(conceptUUID)
 
 	assert.NoError(annotationsDriver.Write(contentUUID, updatedAnnotationsToWrite), "Failed to write updated annotations")
 	readAnnotationsForContentUUIDAndCheckKeyFieldsMatch(t, contentUUID, updatedAnnotationsToWrite)
@@ -519,31 +297,12 @@ func TestConnectivityCheck(t *testing.T) {
 
 func TestCreateAnnotationQuery(t *testing.T) {
 	assert := assert.New(t)
-	annotationToWrite := annotation{
-		Thing: thing{ID: getURI(oldConceptUUID),
-			PrefLabel: "prefLabel",
-			Types: []string{
-				"http://www.ft.com/ontology/organisation/Organisation",
-				"http://www.ft.com/ontology/core/Thing",
-				"http://www.ft.com/ontology/concept/Concept",
-			}},
-		Provenances: []provenance{
-			{
-				Scores: []score{
-					score{ScoringSystem: relevanceScoringSystem, Value: 0.9},
-					score{ScoringSystem: confidenceScoringSystem, Value: 0.8},
-				},
-				AgentRole: "http://api.ft.com/things/0edd3c31-1fd0-4ef6-9230-8d545be3880a",
-				AtTime:    "2016-01-01T19:43:47.314Z",
-			},
-		},
-	}
+	annotationToWrite := exampleConcept(oldConceptUUID)
 
 	query, err := createAnnotationQuery(contentUUID, annotationToWrite, v2PlatformVersion)
 	assert.NoError(err, "Cypher query for creating annotations couldn't be created.")
 	params := query.Parameters["annProps"].(map[string]interface{})
 	assert.Equal(v2PlatformVersion, params["platformVersion"], fmt.Sprintf("\nExpected: %s\nActual: %s", v2PlatformVersion, params["platformVersion"]))
-
 }
 
 func TestGetRelationshipFromPredicate(t *testing.T) {
@@ -566,27 +325,7 @@ func TestGetRelationshipFromPredicate(t *testing.T) {
 
 func TestCreateAnnotationQueryWithPredicate(t *testing.T) {
 	assert := assert.New(t)
-	annotationToWrite := annotation{
-		Thing: thing{ID: getURI(oldConceptUUID),
-			PrefLabel: "prefLabel",
-			Types: []string{
-				"http://www.ft.com/ontology/organisation/Organisation",
-				"http://www.ft.com/ontology/core/Thing",
-				"http://www.ft.com/ontology/concept/Concept",
-			},
-			Predicate: "isClassifiedBy",
-		},
-		Provenances: []provenance{
-			{
-				Scores: []score{
-					score{ScoringSystem: relevanceScoringSystem, Value: 0.9},
-					score{ScoringSystem: confidenceScoringSystem, Value: 0.8},
-				},
-				AgentRole: "http://api.ft.com/things/0edd3c31-1fd0-4ef6-9230-8d545be3880a",
-				AtTime:    "2016-01-01T19:43:47.314Z",
-			},
-		},
-	}
+	annotationToWrite := conceptWithPredicate
 
 	query, err := createAnnotationQuery(contentUUID, annotationToWrite, v2PlatformVersion)
 	assert.NoError(err, "Cypher query for creating annotations couldn't be created.")

--- a/annotations/example_data_test.go
+++ b/annotations/example_data_test.go
@@ -1,0 +1,126 @@
+package annotations
+
+var (
+	conceptWithoutAgent = annotations{annotation{
+		Thing: thing{ID: getURI(conceptUUID),
+			PrefLabel: "prefLabel",
+			Types: []string{
+				"http://www.ft.com/ontology/organisation/Organisation",
+				"http://www.ft.com/ontology/core/Thing",
+				"http://www.ft.com/ontology/concept/Concept",
+			}},
+		Provenances: []provenance{
+			{
+				Scores: []score{
+					score{ScoringSystem: relevanceScoringSystem, Value: 0.9},
+					score{ScoringSystem: confidenceScoringSystem, Value: 0.8},
+				},
+				AgentRole: "",
+				AtTime:    "",
+			},
+		},
+	}}
+	conceptWithoutID = annotations{annotation{
+		Thing: thing{
+			PrefLabel: "prefLabel",
+			Types: []string{
+				"http://www.ft.com/ontology/organisation/Organisation",
+				"http://www.ft.com/ontology/core/Thing",
+				"http://www.ft.com/ontology/concept/Concept",
+			}},
+		Provenances: []provenance{
+			{
+				Scores: []score{
+					score{ScoringSystem: relevanceScoringSystem, Value: 0.9},
+					score{ScoringSystem: confidenceScoringSystem, Value: 0.8},
+				},
+				AgentRole: "http://api.ft.com/things/0edd3c31-1fd0-4ef6-9230-8d545be3880a",
+				AtTime:    "2016-01-01T19:43:47.314Z",
+			},
+		},
+	}}
+	conceptWithPredicate = annotation{
+		Thing: thing{ID: getURI(oldConceptUUID),
+			PrefLabel: "prefLabel",
+			Types: []string{
+				"http://www.ft.com/ontology/organisation/Organisation",
+				"http://www.ft.com/ontology/core/Thing",
+				"http://www.ft.com/ontology/concept/Concept",
+			},
+			Predicate: "isClassifiedBy",
+		},
+		Provenances: []provenance{
+			{
+				Scores: []score{
+					score{ScoringSystem: relevanceScoringSystem, Value: 0.9},
+					score{ScoringSystem: confidenceScoringSystem, Value: 0.8},
+				},
+				AgentRole: "http://api.ft.com/things/0edd3c31-1fd0-4ef6-9230-8d545be3880a",
+				AtTime:    "2016-01-01T19:43:47.314Z",
+			},
+		},
+	}
+	multiConceptAnnotations = annotations{annotation{
+		Thing: thing{ID: getURI(conceptUUID),
+			PrefLabel: "prefLabel",
+			Types: []string{
+				"http://www.ft.com/ontology/organisation/Organisation",
+				"http://www.ft.com/ontology/core/Thing",
+				"http://www.ft.com/ontology/concept/Concept",
+			}},
+		Provenances: []provenance{
+			{
+				Scores: []score{
+					score{ScoringSystem: relevanceScoringSystem, Value: 0.9},
+					score{ScoringSystem: confidenceScoringSystem, Value: 0.8},
+				},
+				AgentRole: "http://api.ft.com/things/0edd3c31-1fd0-4ef6-9230-8d545be3880a",
+				AtTime:    "2016-01-01T19:43:47.314Z",
+			},
+		},
+	}, annotation{
+		Thing: thing{ID: getURI(secondConceptUUID),
+			PrefLabel: "prefLabel",
+			Types: []string{
+				"http://www.ft.com/ontology/organisation/Organisation",
+				"http://www.ft.com/ontology/core/Thing",
+				"http://www.ft.com/ontology/concept/Concept",
+			}},
+		Provenances: []provenance{
+			{
+				Scores: []score{
+					score{ScoringSystem: relevanceScoringSystem, Value: 0.4},
+					score{ScoringSystem: confidenceScoringSystem, Value: 0.5},
+				},
+				AgentRole: "http://api.ft.com/things/0edd3c31-1fd0-4ef6-9230-8d545be3880a",
+				AtTime:    "2016-01-01T19:43:47.314Z",
+			},
+		},
+	}}
+)
+
+func exampleConcepts(uuid string) annotations {
+	return annotations{exampleConcept(uuid)}
+}
+
+func exampleConcept(uuid string) annotation {
+	return annotation{
+		Thing: thing{ID: getURI(uuid),
+			PrefLabel: "prefLabel",
+			Types: []string{
+				"http://www.ft.com/ontology/organisation/Organisation",
+				"http://www.ft.com/ontology/core/Thing",
+				"http://www.ft.com/ontology/concept/Concept",
+			}},
+		Provenances: []provenance{
+			{
+				Scores: []score{
+					score{ScoringSystem: relevanceScoringSystem, Value: 0.9},
+					score{ScoringSystem: confidenceScoringSystem, Value: 0.8},
+				},
+				AgentRole: "http://api.ft.com/things/0edd3c31-1fd0-4ef6-9230-8d545be3880a",
+				AtTime:    "2016-01-01T19:43:47.314Z",
+			},
+		},
+	}
+}


### PR DESCRIPTION
Master has been reset to the Production version, so that this bug fix can be pushed out independently.

Changes: 

Adding the lifecycle property to all relationships written by this component; it will be "annotations-v1" or "annotations-v2" for the v1/v2 components respectively.