### PR TITLE
Improved error logging by adding tid and content uuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ _NB You will need to tag a commit in order to build, since the UI asks for a tag
 * `go install`
 * `$GOPATH/bin/annotations-rw-neo4j [--help]`
 
+You have more options here:
+- run neo4j and kafka locally (by docker, or natively)
+- open a tunnel to one of your team clusters that your app can connect to
+- disable the functionality that requires kafka by setting the env var `SHOULD_FORWARD_MESSAGES=false`
+
 ## Endpoints
 
 ### PUT

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ _NB You will need to tag a commit in order to build, since the UI asks for a tag
 * `$GOPATH/bin/annotations-rw-neo4j [--help]`
 
 You have more options here:
-- run neo4j and kafka locally (by docker, or natively)
+- run neo4j and kafka locally (by docker, or as native apps)
 - open a tunnel to one of your team clusters that your app can connect to
 - disable the functionality that requires kafka by setting the env var `SHOULD_FORWARD_MESSAGES=false`
 

--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -320,16 +320,8 @@ func extractScores(scores []Score) (float64, float64, error) {
 }
 
 func buildDeleteQuery(contentUUID string, annotationLifecycle string, includeStats bool) *neoism.CypherQuery {
-	var statement string
-	if annotationLifecycle == nextVideoAnnotationsLifecycle {
-		// TODO this clause should be deleted when all videos in Neo4j have annotations-next-video only as lifecycle and no brightcove reference
-		statement = `	OPTIONAL MATCH (:Thing{uuid:{contentID}})-[r]->(t:Thing)
-					WHERE r.lifecycle={annotationLifecycle} OR r.lifecycle={brightcoveLifecycle}
+	statement := `	OPTIONAL MATCH (:Thing{uuid:{contentID}})-[r{lifecycle:{annotationLifecycle}}]->(t:Thing)
 					DELETE r`
-	} else {
-		statement = `	OPTIONAL MATCH (:Thing{uuid:{contentID}})-[r{lifecycle:{annotationLifecycle}}]->(t:Thing)
-					DELETE r`
-	}
 
 	query := neoism.CypherQuery{
 		Statement:    statement,

--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -182,7 +182,9 @@ func (s service) Count(annotationLifecycle string, platformVersion string) (int,
 }
 
 func (s service) Initialise() error {
-	return nil // No constraints need to be set up
+	return s.conn.EnsureConstraints(map[string]string{
+		"Thing": "uuid",
+	})
 }
 
 func createAnnotationRelationship(relation string) (statement string) {

--- a/annotations/cypher_test.go
+++ b/annotations/cypher_test.go
@@ -31,6 +31,10 @@ const (
 	tid                       = "transaction_id"
 )
 
+func init() {
+	// TODO add index constraints - here, or in the application - decide which is a better place for them to live
+}
+
 func getURI(uuid string) string {
 	return fmt.Sprintf("http://api.ft.com/things/%s", uuid)
 }
@@ -298,8 +302,10 @@ func TestNextVideoAnnotationsUpdateDeletesBrightcoveAnnotations(t *testing.T) {
 	annotationsDriver = getAnnotationsService(t)
 
 	contentQuery := &neoism.CypherQuery{
-		Statement: `MERGE (n:Thing {uuid:{contentUuid}})
-		 	    MERGE (a:Thing{uuid:{conceptUuid}})
+		Statement: `CREATE (n:Thing {uuid:{contentUuid}})
+		 	    CREATE (a:Thing{uuid:{conceptUuid}})
+		 	    CREATE (upp:Identifier:UPPIdentifier{value:{conceptUuid}})
+                	    MERGE (upp)-[:IDENTIFIES]->(a)
 			    CREATE (n)-[rel:MENTIONS{platformVersion:{platformVersion}, lifecycle:{lifecycle}}]->(a)`,
 		Parameters: map[string]interface{}{
 			"contentUuid":     contentUUID,

--- a/annotations/cypher_test.go
+++ b/annotations/cypher_test.go
@@ -44,11 +44,11 @@ func TestDeleteRemovesAnnotationsButNotConceptsOrContent(t *testing.T) {
 	assert.NoError(annotationsDriver.Write(contentUUID, v2AnnotationLifecycle, v2PlatformVersion, tid, annotationsToDelete), "Failed to write annotation")
 	readAnnotationsForContentUUIDAndCheckKeyFieldsMatch(t, contentUUID, v2AnnotationLifecycle, annotationsToDelete)
 
-	deleted, err := annotationsDriver.Delete(contentUUID, v2AnnotationLifecycle)
+	deleted, err := annotationsDriver.Delete(contentUUID, tid, v2AnnotationLifecycle)
 	assert.True(deleted, "Didn't manage to delete annotations for content uuid %s: %s", contentUUID, err)
 	assert.NoError(err, "Error deleting annotation for content uuid %, conceptUUID %s", contentUUID, conceptUUID)
 
-	anns, found, err := annotationsDriver.Read(contentUUID, v2AnnotationLifecycle)
+	anns, found, err := annotationsDriver.Read(contentUUID, tid, v2AnnotationLifecycle)
 
 	assert.Equal(Annotations{}, anns, "Found annotation for content %s when it should have been deleted", contentUUID)
 	assert.False(found, "Found annotation for content %s when it should have been deleted", contentUUID)
@@ -112,7 +112,7 @@ func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithoutLifecy
 	assert.NoError(annotationsDriver.Write(contentUUID, v2AnnotationLifecycle, v2PlatformVersion, tid, annotationsToWrite), "Failed to write annotation")
 	checkRelationship(assert, contentUUID, "v2")
 
-	deleted, err := annotationsDriver.Delete(contentUUID, v2AnnotationLifecycle)
+	deleted, err := annotationsDriver.Delete(contentUUID, tid, v2AnnotationLifecycle)
 	assert.True(deleted, "Didn't manage to delete annotations for content uuid %s", contentUUID)
 	assert.NoError(err, "Error deleting annotations for content uuid %s", contentUUID)
 
@@ -159,7 +159,7 @@ func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithContentLi
 	assert.NoError(annotationsDriver.Write(contentUUID, v2AnnotationLifecycle, v2PlatformVersion, tid, annotationsToWrite), "Failed to write annotation")
 	checkRelationship(assert, contentUUID, "v2")
 
-	deleted, err := annotationsDriver.Delete(contentUUID, v2AnnotationLifecycle)
+	deleted, err := annotationsDriver.Delete(contentUUID, tid, v2AnnotationLifecycle)
 	assert.True(deleted, "Didn't manage to delete annotations for content uuid %s", contentUUID)
 	assert.NoError(err, "Error deleting annotations for content uuid %s", contentUUID)
 
@@ -184,6 +184,8 @@ func TestWriteDoesNotRemoveExistingIsClassifiedByBrandRelationshipsWithContentLi
 func TestWriteDoesRemoveExistingIsClassifiedForV1TermsAndTheirRelationships(t *testing.T) {
 	assert := assert.New(t)
 	logger.InitDefaultLogger("annotations-rw")
+
+	defer cleanDB(t, assert)
 	annotationsDriver := getAnnotationsService(t)
 
 	createContentQuery := &neoism.CypherQuery{
@@ -211,7 +213,7 @@ func TestWriteDoesRemoveExistingIsClassifiedForV1TermsAndTheirRelationships(t *t
 	err := annotationsDriver.conn.CypherBatch([]*neoism.CypherQuery{contentQuery})
 
 	assert.NoError(annotationsDriver.Write(contentUUID, v1AnnotationLifecycle, v1PlatformVersion, tid, exampleConcepts(conceptUUID)), "Failed to write annotation")
-	found, err := annotationsDriver.Delete(contentUUID, v1AnnotationLifecycle)
+	found, err := annotationsDriver.Delete(contentUUID, tid, v1AnnotationLifecycle)
 	assert.True(found, "Didn't manage to delete annotations for content uuid %s", contentUUID)
 	assert.NoError(err, "Error deleting annotations for content uuid %s", contentUUID)
 
@@ -260,11 +262,6 @@ func TestWriteDoesRemoveExistingIsClassifiedForV1TermsAndTheirRelationships(t *t
 	}
 
 	annotationsDriver.conn.CypherBatch([]*neoism.CypherQuery{removeRelationshipQuery})
-
-	err = deleteNode(annotationsDriver, brandUUID)
-	assert.NoError(err, "Error trying to delete concept node with uuid %s, err=%v", brandUUID, err)
-	err = deleteNode(annotationsDriver, secondConceptUUID)
-	assert.NoError(err, "Error trying to delete concept node with uuid %s, err=%v", secondConceptUUID, err)
 }
 
 func TestWriteAndReadMultipleAnnotations(t *testing.T) {
@@ -364,7 +361,7 @@ func TestNextVideoDeleteCleansAlsoBrightcoveAnnotations(t *testing.T) {
 	err := annotationsDriver.conn.CypherBatch([]*neoism.CypherQuery{contentQuery})
 	assert.NoError(err, "Error creating test data in database.")
 
-	_, err = annotationsDriver.Delete(contentUUID, nextVideoAnnotationsLifecycle)
+	_, err = annotationsDriver.Delete(contentUUID, tid, nextVideoAnnotationsLifecycle)
 	assert.NoError(err, "Failed to delete annotation.")
 
 	result := []struct {
@@ -529,7 +526,7 @@ func getAnnotationsService(t *testing.T) service {
 func readAnnotationsForContentUUIDAndCheckKeyFieldsMatch(t *testing.T, contentUUID string, annotationLifecycle string, expectedAnnotations []Annotation) {
 	assert := assert.New(t)
 	logger.InitDefaultLogger("annotations-rw")
-	storedThings, found, err := annotationsDriver.Read(contentUUID, annotationLifecycle)
+	storedThings, found, err := annotationsDriver.Read(contentUUID, tid, annotationLifecycle)
 	storedAnnotations := storedThings.(Annotations)
 
 	assert.NoError(err, "Error finding annotations for contentUUID %s", contentUUID)
@@ -650,7 +647,7 @@ func checkRelationship(assert *assert.Assertions, contentID string, platformVers
 
 func cleanUp(t *testing.T, contentUUID string, annotationLifecycle string, conceptUUIDs []string) {
 	assert := assert.New(t)
-	found, err := annotationsDriver.Delete(contentUUID, annotationLifecycle)
+	found, err := annotationsDriver.Delete(contentUUID, tid, annotationLifecycle)
 	assert.True(found, "Didn't manage to delete annotations for content uuid %s", contentUUID)
 	assert.NoError(err, "Error deleting annotations for content uuid %s", contentUUID)
 
@@ -668,6 +665,9 @@ func cleanDB(t *testing.T, assert *assert.Assertions) {
 	qs := []*neoism.CypherQuery{
 		{
 			Statement: fmt.Sprintf("MATCH (mc:Thing {uuid: '%v'}) DETACH DELETE mc", contentUUID),
+		},
+		{
+			Statement: fmt.Sprintf("MATCH (fc:Identifier {value: '%v'}) DETACH DELETE fc", conceptUUID),
 		},
 		{
 			Statement: fmt.Sprintf("MATCH (fc:Thing {uuid: '%v'}) DETACH DELETE fc", conceptUUID),

--- a/app.go
+++ b/app.go
@@ -176,7 +176,14 @@ func setupAnnotationsService(neoURL string, bathSize int) annotations.Service {
 		logger.WithError(err).Fatal("Error connecting to Neo4j")
 	}
 
+	annotationsService := annotations.NewCypherAnnotationsService(db)
+	err = annotationsService.Initialise()
+	if err != nil {
+		logger.Errorf("annotations service has not been initalised correctly %s", err)
+	}
+
 	return annotations.NewCypherAnnotationsService(db)
+	return annotationsService
 }
 
 func setupMessageProducer(brokerAddress string, producerTopic string) kafka.Producer {

--- a/http_handler.go
+++ b/http_handler.go
@@ -53,7 +53,8 @@ func (hh *httpHandler) GetAnnotations(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	annotations, found, err := hh.annotationsService.Read(uuid, lifecycle)
+	tid := transactionidutils.GetTransactionIDFromRequest(r)
+	annotations, found, err := hh.annotationsService.Read(uuid, tid, lifecycle)
 	if err != nil {
 		msg := fmt.Sprintf("Error getting annotations (%v)", err)
 		writeJSONError(w, msg, http.StatusServiceUnavailable)
@@ -90,7 +91,8 @@ func (hh *httpHandler) DeleteAnnotations(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	found, err := hh.annotationsService.Delete(uuid, lifecycle)
+	tid := transactionidutils.GetTransactionIDFromRequest(r)
+	found, err := hh.annotationsService.Delete(uuid, tid, lifecycle)
 	if err != nil {
 		writeJSONError(w, err.Error(), http.StatusServiceUnavailable)
 		return

--- a/http_handler_test.go
+++ b/http_handler_test.go
@@ -137,7 +137,7 @@ func (suite *HttpHandlerTestSuite) TestPutHandler_ForwardingFailed() {
 }
 
 func (suite *HttpHandlerTestSuite) TestGetHandler_Success() {
-	suite.annotationsService.On("Read", knownUUID, annotationLifecycle).Return(suite.annotations, true, nil)
+	suite.annotationsService.On("Read", knownUUID, mock.Anything, annotationLifecycle).Return(suite.annotations, true, nil)
 	request := newRequest("GET", fmt.Sprintf("/content/%s/annotations/%s", knownUUID, annotationLifecycle), "application/json", nil)
 	rec := httptest.NewRecorder()
 	router(&httpHandler{suite.annotationsService, suite.producer, suite.originMap, suite.lifecycleMap, suite.messageType}, &suite.healthCheckHandler).ServeHTTP(rec, request)
@@ -148,7 +148,7 @@ func (suite *HttpHandlerTestSuite) TestGetHandler_Success() {
 }
 
 func (suite *HttpHandlerTestSuite) TestGetHandler_NotFound() {
-	suite.annotationsService.On("Read", knownUUID, annotationLifecycle).Return(nil, false, nil)
+	suite.annotationsService.On("Read", knownUUID, mock.Anything, annotationLifecycle).Return(nil, false, nil)
 	request := newRequest("GET", fmt.Sprintf("/content/%s/annotations/%s", knownUUID, annotationLifecycle), "application/json", nil)
 	rec := httptest.NewRecorder()
 	router(&httpHandler{suite.annotationsService, suite.producer, suite.originMap, suite.lifecycleMap, suite.messageType}, &suite.healthCheckHandler).ServeHTTP(rec, request)
@@ -156,7 +156,7 @@ func (suite *HttpHandlerTestSuite) TestGetHandler_NotFound() {
 }
 
 func (suite *HttpHandlerTestSuite) TestGetHandler_ReadError() {
-	suite.annotationsService.On("Read", knownUUID, annotationLifecycle).Return(nil, false, errors.New("Read error"))
+	suite.annotationsService.On("Read", knownUUID, mock.Anything, annotationLifecycle).Return(nil, false, errors.New("Read error"))
 	request := newRequest("GET", fmt.Sprintf("/content/%s/annotations/%s", knownUUID, annotationLifecycle), "application/json", nil)
 	rec := httptest.NewRecorder()
 	router(&httpHandler{suite.annotationsService, suite.producer, suite.originMap, suite.lifecycleMap, suite.messageType}, &suite.healthCheckHandler).ServeHTTP(rec, request)
@@ -164,7 +164,7 @@ func (suite *HttpHandlerTestSuite) TestGetHandler_ReadError() {
 }
 
 func (suite *HttpHandlerTestSuite) TestDeleteHandler_Success() {
-	suite.annotationsService.On("Delete", knownUUID, annotationLifecycle).Return(true, nil)
+	suite.annotationsService.On("Delete", knownUUID, mock.Anything, annotationLifecycle).Return(true, nil)
 	request := newRequest("DELETE", fmt.Sprintf("/content/%s/annotations/%s", knownUUID, annotationLifecycle), "application/json", nil)
 	rec := httptest.NewRecorder()
 	router(&httpHandler{suite.annotationsService, suite.producer, suite.originMap, suite.lifecycleMap, suite.messageType}, &suite.healthCheckHandler).ServeHTTP(rec, request)
@@ -172,7 +172,7 @@ func (suite *HttpHandlerTestSuite) TestDeleteHandler_Success() {
 }
 
 func (suite *HttpHandlerTestSuite) TestDeleteHandler_NotFound() {
-	suite.annotationsService.On("Delete", knownUUID, annotationLifecycle).Return(false, nil)
+	suite.annotationsService.On("Delete", knownUUID, mock.Anything, annotationLifecycle).Return(false, nil)
 	request := newRequest("DELETE", fmt.Sprintf("/content/%s/annotations/%s", knownUUID, annotationLifecycle), "application/json", nil)
 	rec := httptest.NewRecorder()
 	router(&httpHandler{suite.annotationsService, suite.producer, suite.originMap, suite.lifecycleMap, suite.messageType}, &suite.healthCheckHandler).ServeHTTP(rec, request)
@@ -180,7 +180,7 @@ func (suite *HttpHandlerTestSuite) TestDeleteHandler_NotFound() {
 }
 
 func (suite *HttpHandlerTestSuite) TestDeleteHandler_DeleteError() {
-	suite.annotationsService.On("Delete", knownUUID, annotationLifecycle).Return(false, errors.New("Delete error"))
+	suite.annotationsService.On("Delete", knownUUID, mock.Anything, annotationLifecycle).Return(false, errors.New("Delete error"))
 	request := newRequest("DELETE", fmt.Sprintf("/content/%s/annotations/%s", knownUUID, annotationLifecycle), "application/json", nil)
 	rec := httptest.NewRecorder()
 	router(&httpHandler{suite.annotationsService, suite.producer, suite.originMap, suite.lifecycleMap, suite.messageType}, &suite.healthCheckHandler).ServeHTTP(rec, request)
@@ -251,12 +251,12 @@ func (as *mockAnnotationsService) Write(contentUUID string, annotationLifecycle 
 	args := as.Called(contentUUID, annotationLifecycle, platformVersion, tid, thing)
 	return args.Error(0)
 }
-func (as *mockAnnotationsService) Read(contentUUID string, annotationLifecycle string) (thing interface{}, found bool, err error) {
-	args := as.Called(contentUUID, annotationLifecycle)
+func (as *mockAnnotationsService) Read(contentUUID string, tid string, annotationLifecycle string) (thing interface{}, found bool, err error) {
+	args := as.Called(contentUUID, tid, annotationLifecycle)
 	return args.Get(0), args.Bool(1), args.Error(2)
 }
-func (as *mockAnnotationsService) Delete(contentUUID string, annotationLifecycle string) (found bool, err error) {
-	args := as.Called(contentUUID, annotationLifecycle)
+func (as *mockAnnotationsService) Delete(contentUUID string, tid string, annotationLifecycle string) (found bool, err error) {
+	args := as.Called(contentUUID, tid, annotationLifecycle)
 	return args.Bool(0), args.Error(1)
 }
 func (as *mockAnnotationsService) Check() (err error) {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -19,7 +19,7 @@
 			"path": "github.com/Financial-Times/go-logger",
 			"revision": "ec38b420999cfcbc86816afb47f365dad510450c",
 			"revisionTime": "2017-10-20T13:42:12Z",
-			"version": "=0.0.3",
+			"version": "0.0.3",
 			"versionExact": "0.0.3"
 		},
 		{


### PR DESCRIPTION
Changes included in this PR:
- improved logging (adding tid and content uuid)
- updated vendor.json
- fixed test (they pass both locally and on CircleCI)
- included uniqueness constraint check - implemented by Galia  in this [PR](https://github.com/Financial-Times/annotations-rw-neo4j/pull/28/files)
- brightcove references removal (as a little repo cleanup)
