### PR TITLE
FIxes to writing ManagedLocation annotations

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -183,6 +183,17 @@
   revision = "2bb1b664bcff821e02b2a0644cd29c7e824d54f8"
 
 [[projects]]
+  digest = "1:1f4b55d7c57681ad91b7ce3ac7c8e7b139e6dd2f477c5f87e6a7749d298645dc"
+  name = "github.com/joho/godotenv"
+  packages = [
+    ".",
+    "autoload",
+  ]
+  pruneopts = "UT"
+  revision = "23d116af351c84513e1946b527c88823e476be13"
+  version = "v1.3.0"
+
+[[projects]]
   branch = "master"
   digest = "1:f44d34fda864bed6d6c71514cd40b2ee097e6e67f745d5d014113e1faa5af8b7"
   name = "github.com/konsorten/go-windows-terminal-sequences"
@@ -361,6 +372,7 @@
     "github.com/gorilla/mux",
     "github.com/jawher/mow.cli",
     "github.com/jmcvetta/neoism",
+    "github.com/joho/godotenv/autoload",
     "github.com/pkg/errors",
     "github.com/rcrowley/go-metrics",
     "github.com/stretchr/testify/assert",

--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -148,6 +148,7 @@ func (s service) Write(contentUUID string, annotationLifecycle string, platformV
 	logger.WithTransactionID(tid).WithUUID(contentUUID).Debugf("Writing statements to neo4j: %v", statements)
 	if err := s.conn.CypherBatch(queries); err != nil {
 		logger.WithError(err).WithTransactionID(tid).WithUUID(contentUUID).Error("Error executing write queries in neo4j!")
+		return err
 	}
 	return nil
 }
@@ -195,8 +196,7 @@ func (s service) Initialise() error {
 func createAnnotationRelationship(relation string) (statement string) {
 	stmt := `
                 MERGE (content:Thing{uuid:{contentID}})
-                MERGE (upp:Identifier:UPPIdentifier{value:{conceptID}})
-                MERGE (upp)-[:IDENTIFIES]->(concept:Thing) ON CREATE SET concept.uuid = {conceptID}
+                MERGE (concept:Thing{uuid:{conceptID}})
                 MERGE (content)-[pred:%s {lifecycle:{annotationLifecycle}}]->(concept)
                 SET pred={annProps}
           `

--- a/app.go
+++ b/app.go
@@ -21,6 +21,8 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/jawher/mow.cli"
 	"github.com/rcrowley/go-metrics"
+
+	_ "github.com/joho/godotenv/autoload"
 )
 
 func main() {


### PR DESCRIPTION
- Stop errors in cypher queries allowing a successful response
- Stop using UPPIdentifiers