### PR TITLE
Fix/uppsf 978 add validation for empty predicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Command line options:
 /content/{annotatedContentId}/annotations/{annotations-lifecycle}
 
 Each annotation is added with a relationship according to the predicate property from the payload.
-If that is empty: a default MENTIONS relationship will be added between the content and a concept.
+The predicate property is required and it's value has to be equal to one of the keys from the `relations` map in annotations/model.go
 
 This operation acts as a replace - all existing annotations are removed, and the new ones are created - for the specified annotations-lifecycle.
 Supplying an empty list as the request body will remove all annotations for the content.

--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -191,10 +191,6 @@ func createAnnotationRelationship(relation string) (statement string) {
 }
 
 func getRelationshipFromPredicate(predicate string) (string, error) {
-	if predicate == "" {
-		return relations["mentions"], nil
-	}
-
 	r, ok := relations[predicate]
 	if !ok {
 		return "", UnsupportedPredicateErr

--- a/annotations/cypher_integration_test.go
+++ b/annotations/cypher_integration_test.go
@@ -372,6 +372,7 @@ func TestWriteAndReadMultipleAnnotations(t *testing.T) {
 					"http://www.ft.com/ontology/core/Thing",
 					"http://www.ft.com/ontology/concept/Concept",
 				},
+				Predicate: "mentions",
 			},
 			Provenances: []Provenance{
 				{

--- a/annotations/cypher_test.go
+++ b/annotations/cypher_test.go
@@ -1,6 +1,7 @@
 package annotations
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -99,6 +100,16 @@ func TestCreateAnnotationQueryWithPredicate(t *testing.T) {
 	}
 }
 
+func TestCreateAnnotationQueryWithoutPredicate(t *testing.T) {
+	assert := assert.New(t)
+	logger.InitDefaultLogger("annotations-rw")
+	annotation := exampleConcept(oldConceptUUID)
+	annotation.Thing.Predicate = ""
+
+	_, err := createAnnotationQuery(contentUUID, annotation, v2PlatformVersion, v2AnnotationLifecycle)
+	assert.True(errors.Is(err, UnsupportedPredicateErr), "Creating annotation without predicate is not allowed.")
+}
+
 func TestGetRelationshipFromPredicate(t *testing.T) {
 	var tests = []struct {
 		predicate    string
@@ -106,9 +117,13 @@ func TestGetRelationshipFromPredicate(t *testing.T) {
 	}{
 		{"mentions", "MENTIONS"},
 		{"isClassifiedBy", "IS_CLASSIFIED_BY"},
-		{"", "MENTIONS"},
+		{"implicitlyClassifiedBy", "IMPLICITLY_CLASSIFIED_BY"},
 		{"about", "ABOUT"},
+		{"isPrimarilyClassifiedBy", "IS_PRIMARILY_CLASSIFIED_BY"},
+		{"majorMentions", "MAJOR_MENTIONS"},
 		{"hasAuthor", "HAS_AUTHOR"},
+		{"hasContributor", "HAS_CONTRIBUTOR"},
+		{"hasDisplayTag", "HAS_DISPLAY_TAG"},
 		{"hasBrand", "HAS_BRAND"},
 	}
 

--- a/annotations/example_data_test.go
+++ b/annotations/example_data_test.go
@@ -20,7 +20,9 @@ var (
 				"http://www.ft.com/ontology/organisation/Organisation",
 				"http://www.ft.com/ontology/core/Thing",
 				"http://www.ft.com/ontology/concept/Concept",
-			}},
+			},
+			Predicate: "mentions",
+		},
 		Provenances: []Provenance{
 			{
 				Scores: []Score{
@@ -192,7 +194,9 @@ func exampleConcept(uuid string) Annotation {
 				"http://www.ft.com/ontology/organisation/Organisation",
 				"http://www.ft.com/ontology/core/Thing",
 				"http://www.ft.com/ontology/concept/Concept",
-			}},
+			},
+			Predicate: "mentions",
+		},
 		Provenances: []Provenance{
 			{
 				Scores: []Score{

--- a/http_handler.go
+++ b/http_handler.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,7 +15,6 @@ import (
 	transactionidutils "github.com/Financial-Times/transactionid-utils-go"
 
 	"github.com/gorilla/mux"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -187,7 +187,7 @@ func (hh *httpHandler) PutAnnotations(w http.ResponseWriter, r *http.Request) {
 
 	tid := transactionidutils.GetTransactionIDFromRequest(r)
 	err = hh.annotationsService.Write(uuid, lifecycle, platformVersion, tid, anns)
-	if err == annotations.UnsupportedPredicateErr {
+	if errors.Is(err, annotations.UnsupportedPredicateErr) {
 		hh.log.WithUUID(uuid).WithTransactionID(tid).WithError(err).Error("invalid predicate provided")
 		writeJSONError(w, "Please provide a valid predicate", http.StatusBadRequest)
 		return

--- a/http_handler.go
+++ b/http_handler.go
@@ -189,7 +189,7 @@ func (hh *httpHandler) PutAnnotations(w http.ResponseWriter, r *http.Request) {
 	err = hh.annotationsService.Write(uuid, lifecycle, platformVersion, tid, anns)
 	if err == annotations.UnsupportedPredicateErr {
 		hh.log.WithUUID(uuid).WithTransactionID(tid).WithError(err).Error("invalid predicate provided")
-		writeJSONError(w, "Please provide a valid predicate, or leave blank for the default predicate (MENTIONS)", http.StatusBadRequest)
+		writeJSONError(w, "Please provide a valid predicate", http.StatusBadRequest)
 		return
 	}
 


### PR DESCRIPTION
# Description

## What

Add validation which checks whether each annotation has specified predicate value

## Why

Currently `annotations-rw-neo4j` accepts empty string or even missing "predicate" and `MENTIONS` relationship. 
We should add basic validation that we have "predicate" value.

## Note for the reviewers

This is a breaking change for the apis that depend on the current behaviour. The only api that depends on it is the `v2-content-annotator`. However it has been updated not to depend on that feature. ([PR](https://github.com/Financial-Times/content-annotator/pull/24))
For this reason the PR is marked as **Feature** not as **Breaking change**  

Also it might be easier for you if you look through each of the commits separately.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
