### PR TITLE
Stop forwarding to PostConceptSuggestions

### DIFF
--- a/helm/annotations-rw-neo4j/app-configs/suggestions-rw-neo4j_eks_delivery.yaml
+++ b/helm/annotations-rw-neo4j/app-configs/suggestions-rw-neo4j_eks_delivery.yaml
@@ -4,6 +4,5 @@ service:
   name: suggestions-rw-neo4j
 env:
   SHOULD_CONSUME_MESSAGES: false
-  SHOULD_FORWARD_MESSAGES: true
-  PRODUCER_TOPIC: PostConceptSuggestions
+  SHOULD_FORWARD_MESSAGES: false
   LIFECYCLE_CONFIG_PATH: suggestion-config.json

--- a/runbooks/suggestions-rw-neo4j_runbook.md
+++ b/runbooks/suggestions-rw-neo4j_runbook.md
@@ -28,7 +28,7 @@ AWS
 
 ## Architecture
 
-Suggestions RW receives PUT requests with suggested annotations in the payload, stores them in the graph database (Neo4j) and forwards them on to the PostConceptSuggestions queue. The Annotation Writer owns all annotations that are linked to a piece of content that are written with lifecycle=annotations-v2.
+Suggestions RW receives PUT requests with suggested annotations in the payload, stores them in the graph database (Neo4j). The Annotation Writer owns all annotations that are linked to a piece of content that are written with lifecycle=annotations-v2.
 
 ## Contains Personal Data
 


### PR DESCRIPTION
# Description

## What

Stop forwarding messages to PostConceptSuggestions topic.

## Why

Looking at our current [Kafka topics diagram](https://lucid.app/lucidchart/72544b1a-9ed2-4b0b-90c5-fb749c6b7fda/edit?invitationId=inv_8845e9ff-a37f-4c7b-9cd4-d8568327064d&page=D0i.FFbelbdG#) it is apparent that there are no consumers for PostConceptSuggestions topic and we only produce messages to it. That makes the topic redundant and we can get rid of it.

## Anything, in particular, you'd like to highlight to reviewers

Doing a [Github search for the topic](https://github.com/search?q=org%3AFinancial-Times+PostConceptSuggestions&type=code) it looks like this is the only service using it.
Additionally I have checked if there is any consumer for the topic in Zookeeper and there are none.

## Scope and particulars of this PR (Please tick all that apply)

- [X] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [X] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
