### PR TITLE
Update the origin system id for the automatic suggestions flow

### DIFF
--- a/suggestion-config.json
+++ b/suggestion-config.json
@@ -1,6 +1,6 @@
 {
   "originMap": {
-    "concept-suggestor": "annotations-v2"
+    "v2-annotations": "annotations-v2"
   },
   "lifecycleMap": {
     "annotations-v2": "v2"


### PR DESCRIPTION
# Description

## What

The origin system id has been changed from `concept-suggestor` to `v2-annotations` in https://github.com/Financial-Times/concept-suggestion-ontotext but was not reflected in flow for ConceptSuggestions topic.

## Why

https://financialtimes.atlassian.net/browse/UPPSF-3204


## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [X] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [X] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
