### PR TITLE
Do not write zero relevance and confidence scores for pac annotations

### DIFF
--- a/annotations/cypher.go
+++ b/annotations/cypher.go
@@ -226,8 +226,12 @@ func createAnnotationQuery(contentUUID string, ann Annotation, platformVersion s
 		params["annotatedDateEpoch"] = ann.AnnotatedDateEpoch
 		params["annotatedDate"] = ann.AnnotatedDate
 	}
-	params["relevanceScore"] = ann.RelevanceScore
-	params["confidenceScore"] = ann.ConfidenceScore
+	if ann.RelevanceScore != 0.0 {
+		params["relevanceScore"] = ann.RelevanceScore
+	}
+	if ann.ConfidenceScore != 0.0 {
+		params["confidenceScore"] = ann.ConfidenceScore
+	}
 
 	relation, err := getRelationshipFromPredicate(ann.Predicate)
 	if err != nil {


### PR DESCRIPTION
# Description

## What

Do not write zero relevance and confidence scores for pac annotations. I have checked that there are no suggestions in neo4j with zero confidence or relevance score, that is why I am comparing the incoming values with zero. Furthermore, the relevance and confidence scores for the videos is hardcoded to 0.9.

## Why

JIRA Ticket [UPPSF-4271](https://financialtimes.atlassian.net/browse/UPPSF-4271)

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [ ] Test coverage is not significantly decreased
- [ ] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [ ] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)


[UPPSF-4271]: https://financialtimes.atlassian.net/browse/UPPSF-4271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ